### PR TITLE
[Travis] Do not build branches prefixed with pr/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ compiler: clang
 os: linux
 sudo: false
 
+# Do not build branches of the form "pr/*". By prefixing pull requests coming
+# from branches inside the repository with pr/, this avoids building both the
+# branch push _and_ the pull request.
+branches:
+  except: /pr\/.*/
+
 
 matrix:
   allow_failures:


### PR DESCRIPTION
This avoids building both the push commit and the pull request, which is frankly annoying. Note that this only concerns pull requests coming from branches _inside_ the repository, since push commits from forks are not normally built on Travis.