### PR TITLE
Provide to_xxx equivalent for to<xxx_tag>

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -20,15 +20,6 @@ if [ os.environ TRAVIS ] {
   path-constant HANA_SOURCE_DIR : $(BOOST_ROOT)/libs/hana ;
 }
 
-# This hack is required because Boost.Build can't feed .md files to Doxygen.
-make tutorial.hpp : tutorial.md : make_tutorial_hpp ;
-actions make_tutorial_hpp
-{
-  echo '/*!' > tutorial.hpp
-  cat tutorial.md >> tutorial.hpp
-  echo '*/' >> tutorial.hpp
-}
-
 doxygen hana.html
     :
         [ glob ../include/boost/hana/*.hpp ]
@@ -49,8 +40,6 @@ doxygen hana.html
         ../include/boost/hana.hpp
         tutorial.hpp
     :
-      <dependency>tutorial.hpp
-
       <doxygen:param>PROJECT_NAME="Boost.Hana"
       <doxygen:param>PROJECT_BRIEF="Your standard library for metaprogramming"
       <doxygen:param>PROJECT_LOGO=$(HANA_SOURCE_DIR)/doc/Boost.png

--- a/doc/tutorial.hpp
+++ b/doc/tutorial.hpp
@@ -100,7 +100,7 @@ following C++14 features (non-exhaustively):
 - Automatically deduced return type
 - All the C++14 type traits from the `<type_traits>` header
 
-
+More information for specific platforms is available on [the wiki][Hana.wiki].
 
 
 
@@ -3850,6 +3850,7 @@ modified as little as possible to work with this reimplementation.
 [Hana.issues]: https://github.com/boostorg/hana/issues
 [Hana.readme]: https://goo.gl/RPd0sV <!-- Original GitHub link can't be resolved by Doxygen -->
 [Hana.repository]: https://github.com/boostorg/hana
+[Hana.wiki]: https://github.com/boostorg/hana/wiki
 [Homebrew.devel-only]: https://github.com/Homebrew/homebrew-devel-only
 [Homebrew]: http://brew.sh
 [lie-to-children]: http://en.wikipedia.org/wiki/Lie-to-children

--- a/example/ext/boost/fusion/tuple.cpp
+++ b/example/ext/boost/fusion/tuple.cpp
@@ -23,7 +23,7 @@ struct Cat  { std::string name; };
 struct Dog  { std::string name; };
 
 int main() {
-    fusion::tuple<Fish, Cat, Dog> animals{{"Nemo"}, {"Garfield"}, {"Snoopy"}};
+    fusion::tuple<Fish, Cat, Dog> animals{Fish{"Nemo"}, Cat{"Garfield"}, Dog{"Snoopy"}};
     hana::front(animals).name = "Moby Dick";
 
     auto names = hana::transform(animals, [](auto a) {

--- a/example/ext/boost/fusion/vector.cpp
+++ b/example/ext/boost/fusion/vector.cpp
@@ -23,7 +23,7 @@ struct Cat  { std::string name; };
 struct Dog  { std::string name; };
 
 int main() {
-    fusion::vector<Fish, Cat, Dog> animals{{"Nemo"}, {"Garfield"}, {"Snoopy"}};
+    fusion::vector<Fish, Cat, Dog> animals{Fish{"Nemo"}, Cat{"Garfield"}, Dog{"Snoopy"}};
     hana::front(animals).name = "Moby Dick";
 
     auto names = hana::transform(animals, [](auto a) {

--- a/include/boost/hana/map.hpp
+++ b/include/boost/hana/map.hpp
@@ -294,6 +294,11 @@ namespace boost { namespace hana {
             );
         }
     };
+
+    //! Equivalent to `to<map_tag>`; provided for convenience.
+    //! @relates hana::map
+    constexpr to_t<map_tag> to_map{};
+
 }} // end namespace boost::hana
 
 #endif // !BOOST_HANA_MAP_HPP

--- a/include/boost/hana/set.hpp
+++ b/include/boost/hana/set.hpp
@@ -304,6 +304,11 @@ namespace boost { namespace hana {
                                    hana::erase_key);
         }
     };
+
+    //! Equivalent to `to<set_tag>`; provided for convenience.
+    //! @relates hana::set
+    constexpr to_t<set_tag> to_set{};
+
 }} // end namespace boost::hana
 
 #endif // !BOOST_HANA_SET_HPP

--- a/include/boost/hana/tuple.hpp
+++ b/include/boost/hana/tuple.hpp
@@ -25,6 +25,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/detail/operators/orderable.hpp>
 #include <boost/hana/fwd/at.hpp>
 #include <boost/hana/fwd/core/make.hpp>
+#include <boost/hana/fwd/core/convert.hpp>
 #include <boost/hana/fwd/drop_front.hpp>
 #include <boost/hana/fwd/find_if.hpp>
 #include <boost/hana/fwd/is_empty.hpp>
@@ -301,6 +302,11 @@ namespace boost { namespace hana {
             return helper<index>(static_cast<Xs&&>(xs), hana::bool_c<index == len>);
         }
     };
+
+    //! Equivalent to `to<tuple_tag>`; provided for convenience.
+    //! @relates hana::tuple
+    constexpr to_t<tuple_tag> to_tuple{};
+
 }} // end namespace boost::hana
 
 #endif // !BOOST_HANA_TUPLE_HPP

--- a/test/map.cpp
+++ b/test/map.cpp
@@ -262,6 +262,14 @@ int main() {
             check(p<1, 1>(), p<2, 2>(), p<3, 3>());
             check(p<1, 1>(), p<2, 2>(), p<3, 3>(), p<4, 4>());
         }
+        
+        // to_map == to<map_tag>
+        {
+            BOOST_HANA_CONSTANT_CHECK(equal(
+                to<map_tag>(foldable(p<1, 1>(), p<2, 2>(), p<1, 99>(), p<2, 99>(), p<3, 3>())),
+                to_map(foldable(p<1, 1>(), p<2, 2>(), p<1, 99>(), p<2, 99>(), p<3, 3>()))
+            ));
+        }
     }
 
 #elif BOOST_HANA_TEST_PART == 3

--- a/test/set.cpp
+++ b/test/set.cpp
@@ -483,6 +483,14 @@ int main() {
                 make_set(ct_eq<1>{}, ct_eq<2>{}, ct_eq<3>{})
             ));
         }
+
+        // to_set == to<set_tag>
+        {
+            BOOST_HANA_CONSTANT_CHECK(equal(
+                to_set(foldable(ct_eq<1>{}, ct_eq<2>{}, ct_eq<3>{}, ct_eq<2>{}, ct_eq<1>{})),
+                to<set_tag>(foldable(ct_eq<1>{}, ct_eq<2>{}, ct_eq<3>{}, ct_eq<2>{}, ct_eq<1>{}))
+            ));
+        }
     }
 
 #elif BOOST_HANA_TEST_PART == 2
@@ -649,5 +657,6 @@ int main() {
         // laws
         test::TestFoldable<set_tag>{eqs};
     }
+
 #endif
 }

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -651,5 +651,18 @@ int main() {
         // laws
         test::TestMonadPlus<tuple_tag>{eq_tuples, predicates, eq_values};
     }
+
+#elif BOOST_HANA_TEST_PART == 10
+    //////////////////////////////////////////////////////////////////////////
+    //to_tuple == to<tuple_tag>
+    //////////////////////////////////////////////////////////////////////////
+    {
+        BOOST_HANA_CONSTANT_CHECK(
+            to<tuple_tag>(tuple_t<int, char, void, int(float)>)
+            ==
+            to_tuple(tuple_t<int, char, void, int(float)>)
+        );
+    }
+
 #endif
 }


### PR DESCRIPTION
As you suggested via email, this is a WIP pull request.

- adding to_map
- adding to_set
- adding to_tuple

WIP - need to add documentation in fwd headers... Suggestions?
I've never used Doxygen before.

WIP - remove doc comments in this commit?

WIP - to_type\<xxx\> mentioned in issue #164 - is this necessary? Why not 
just use to\<xxx\>? Do we want to add STL extensions (to_vector, etc) 
instead?