### PR TITLE
Add support for Clang-cl with Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,82 @@
+# Copyright Louis Dionne 2015
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+shallow_clone: true
+
+os:
+  - Visual Studio 2015
+  # - Visual Studio 2015 CTP
+  # - Visual Studio 2015 CTP 6
+  # - Visual Studio 2015 Preview
+  # - Visual Studio 2015 RC
+  # - MinGW
+
+build:
+  verbosity: detailed
+
+configuration:
+  - Debug
+
+
+environment:
+  matrix:
+    - TESTS_ONLY: true
+    - EXAMPLES_ONLY: true
+
+
+install:
+  ############################################################################
+  # All external dependencies are installed in C:\projects\deps
+  ############################################################################
+  - mkdir C:\projects\deps
+  - cd C:\projects\deps
+
+  ############################################################################
+  # Install Ninja
+  ############################################################################
+  - set NINJA_URL="https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-win.zip"
+  - appveyor DownloadFile %NINJA_URL% -FileName ninja.zip
+  - 7z x ninja.zip -oC:\projects\deps\ninja > nul
+  - set PATH=C:\projects\deps\ninja;%PATH%
+  - ninja --version
+
+  ############################################################################
+  # Install a recent CMake
+  ############################################################################
+  - set CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.0-win32-x86.zip"
+  - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
+  - 7z x cmake.zip -oC:\projects\deps\cmake > nul
+  - set PATH=C:\projects\deps\cmake\bin;%PATH%
+  - cmake --version
+
+  ############################################################################
+  # Install Boost headers (for now, we use Boost 1.59.0 provided by Appveyor)
+  ############################################################################
+  - mklink /D boost C:\Libraries\boost_1_59_0
+  # - set BOOST_URL="http://sourceforge.net/projects/boost/files/boost/1.59.0/boost_1_59_0.zip"
+  # - appveyor DownloadFile %BOOST_URL% -FileName boost.zip
+  # - 7z x boost.zip > nul
+  # - move boost_1_59_0 boost
+
+  ############################################################################
+  # Install a pre-built Clang-cl
+  ############################################################################
+  - set LLVM_URL="https://www.dropbox.com/s/caol8ihddfwqs31/LLVM-3.7.0-win64.zip?dl=1"
+  - appveyor DownloadFile %LLVM_URL% -FileName llvm.zip
+  - 7z x llvm.zip -oC:\projects\deps\llvm > nul
+  - set PATH=C:\projects\deps\llvm\bin;%PATH%
+  - clang-cl -v
+
+
+before_build:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+  - cd C:\projects\hana
+
+
+build_script:
+  - mkdir build
+  - cd build
+  - cmake .. -GNinja -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_CXX_FLAGS="-fms-compatibility-version=19" # -DBOOST_ROOT="C:\projects\deps\boost"
+  - if "%TESTS_ONLY%" == "true" (ninja tests.quick && ctest -R --output-on-failure "test.+")
+  - if "%EXAMPLES_ONLY%" == "true" (ninja examples && ctest -R --output-on-failure "example.+")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,9 @@ build:
 configuration:
   - Debug
 
+branches:
+  except:
+    - /pr\/.+/
 
 environment:
   matrix:

--- a/cmake/CheckCxxCompilerSupport.cmake
+++ b/cmake/CheckCxxCompilerSupport.cmake
@@ -18,33 +18,21 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     ###     cmake .. -DCMAKE_CXX_COMPILER=/path/to/clang
         ")
     endif()
+
     if (MSVC)
         if(${MSVC_VERSION} LESS 1900)
             message(WARNING "
-    ### Your version of Visual Studio is not supported.
-    ### Please upgrade to Visual Studio 2015 or above.
-            ")
-        endif()
-        if(${CMAKE_GENERATOR_TOOLSET} MATCHES "LLVM-*")
-            message(STATUS "Visual Studio platform toolset is ${CMAKE_GENERATOR_TOOLSET}")
-        else()
-            message(WARNING "
-    ### You haven't specified the platform toolset option to cmake.
-    ### Please run cmake for a Windows 32bit solution with
-    ###     cmake -TLLVM-vs2014 ..
-    ### and for a Windows 64bit solution with
-    ###     cmake -TLLVM-vs2014 -G\"Visual Studio 14 2015 Win64\" ..
-    ### which should choose the correct platform toolset automatically.
-            ")
-        endif()
-        if(NOT ${CMAKE_GENERATOR} MATCHES "Visual Studio 14 2015*")
-            message(WARNING "
-    ### You're not using a Visual Studio 2015 generator. Please run cmake
-    ### for a Windows 32bit solution with
-    ###     cmake -TLLVM-vs2014 ..
-    ### and for a Windows 64bit solution with
-    ###     cmake -TLLVM-vs2014 -G\"Visual Studio 14 2015 Win64\" ..
-    ### which should choose the correct platform toolset automatically.
+    ###
+    ### We detected that you were using Clang for Windows with a
+    ### -fms-compatibility-version parameter lower than 19. Only
+    ### -fms-compatibility-version=19 and above are supported by
+    ### Hana for lack of proper C++14 support prior for versions
+    ### below that.
+    ###
+    ### If this diagnostic is wrong and you are not using
+    ### -fms-compatibility-version, please file an issue at
+    ### https://github.com/boostorg/hana/issues.
+    ###
             ")
         endif()
     endif()
@@ -77,13 +65,13 @@ elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
     ")
 elseif (MSVC)
     message(WARNING "
-    ### Native Visual Studio is not supported. Please install pre-built windows
-    ### LLVM/Clang binaries with Visual Studio 2015 integration and run cmake
-    ### for a Windows 32bit solution with
-    ###     cmake -TLLVM-vs2014 ..
-    ### and for a Windows 64bit solution with
-    ###     cmake -TLLVM-vs2014 -G\"Visual Studio 14 2015 Win64\" ..
-    ### which should choose the correct platform toolset automatically.
+    ### Using the native Microsoft compiler (MSVC) is not supported for lack
+    ### of proper C++14 support. However, you can install pre-built Clang for
+    ### Windows binaries (with Visual Studio integration if desired) at
+    ### http://llvm.org/releases/download.html.
+    ###
+    ### More information about how to set up Hana with Clang for Windows is
+    ### available on Hana's wiki at http://git.io/vBYIp.
     ")
 else()
     message(WARNING "

--- a/include/boost/hana/config.hpp
+++ b/include/boost/hana/config.hpp
@@ -17,25 +17,25 @@ Distributed under the Boost Software License, Version 1.0.
 // Detect the compiler
 //////////////////////////////////////////////////////////////////////////////
 
-// MSVC must be first check, otherwise it might fail the build at the first #warning
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__) // MSVC
+    // This must be checked first, because otherwise it produces a fatal
+    // error due to unrecognized #warning directives used below.
+#   pragma message("Warning: the native Microsoft compiler is not supported due to lack of proper C++14 support.")
+
+#elif defined(__clang__) && defined(_MSC_VER) // Clang-cl (Clang for Windows)
+
+#   define BOOST_HANA_CONFIG_CLANG BOOST_HANA_CONFIG_VERSION(               \
+                    __clang_major__, __clang_minor__, __clang_patchlevel__)
+
+#   if BOOST_HANA_CONFIG_CLANG < BOOST_HANA_CONFIG_VERSION(3, 5, 0)
+#       warning "Versions of Clang prior to 3.5.0 are not supported by Hana."
+#   endif
 
 #   if _MSC_VER < 1900
-#       pragma message("Visual Studio 2015 or above is required. Your version is not supported.")
+#       warning "Clang-cl is only supported with the -fms-compatibility-version parameter set to 19 and above."
 #   endif
 
-#   if !defined(__clang__)
-#       pragma message("Note: Visual Studio 2015 is only supported with the LLVM/Clang platform toolset.")
-#   endif
-
-#endif
-
-// Check the compiler for general C++14 capabilities
-#if (__cplusplus < 201400)
-#   warning "Your compiler doesn't provide C++14 or higher capabilities. Try adding the compiler flag '-std=c++14' or '-std=c++1y'."
-#endif
-
-#if defined(__clang__) && defined(__apple_build_version__) // Apple's Clang
+#elif defined(__clang__) && defined(__apple_build_version__) // Apple's Clang
 
 #   if __apple_build_version__ >= 6020049
 #       define BOOST_HANA_CONFIG_CLANG BOOST_HANA_CONFIG_VERSION(3, 6, 0)
@@ -43,7 +43,7 @@ Distributed under the Boost Software License, Version 1.0.
 #       warning "Versions of Apple's Clang prior to the one shipped with Xcode 6.3 are not supported by Hana."
 #   endif
 
-#elif defined(__clang__) // genuine Clang (not Apple's)
+#elif defined(__clang__) // genuine Clang
 
 #   define BOOST_HANA_CONFIG_CLANG BOOST_HANA_CONFIG_VERSION(               \
                 __clang_major__, __clang_minor__, __clang_patchlevel__)
@@ -63,6 +63,13 @@ Distributed under the Boost Software License, Version 1.0.
 
 #   warning "Your compiler is not officially supported by Hana or it was not detected properly."
 
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
+// Check the compiler for general C++14 capabilities
+//////////////////////////////////////////////////////////////////////////////
+#if (__cplusplus < 201400)
+#   warning "Your compiler doesn't provide C++14 or higher capabilities. Try adding the compiler flag '-std=c++14' or '-std=c++1y'."
 #endif
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Once merged, this is going to address #207.

Todo:
- [x] Check what is the smallest working value for `-fms-compatibility-version`, as explained in https://github.com/boostorg/hana/commit/b9d943bfcb8e65a604f950818d8f8498af59c4ca#commitcomment-14602599.

  [Edit: I confirm that `-fms-compatibility-version=18` causes breakage due to missing C++14 facilities, so the smallest admissible value seems to be 19.]
- [x] Adjust warning message when `_MSV_VER < 1900` in `<boost/hana/config.hpp>`.