### PR TITLE
[CMake] Add support for measuring code coverage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ include(CheckCxxCompilerSupport)
 ##############################################################################
 option(BOOST_HANA_ENABLE_WERROR   "Fail and stop if a warning is triggered." OFF)
 option(BOOST_HANA_ENABLE_MEMCHECK "Run the unit tests and examples under Valgrind if it is found." OFF)
+option(BOOST_HANA_ENABLE_COVERAGE "Enable code coverage measurement in the unit tests. Requires CMAKE_BUILD_TYPE=Debug" OFF)
 option(BOOST_HANA_ENABLE_CONCEPT_CHECKS "Enable concept checking in the interface methods." ON)
 
 option(BOOST_HANA_ENABLE_STRING_UDL
@@ -50,6 +51,15 @@ endif()
 
 if (NOT BOOST_HANA_ENABLE_CONCEPT_CHECKS)
     add_definitions(-DBOOST_HANA_CONFIG_DISABLE_CONCEPT_CHECKS)
+endif()
+
+if (BOOST_HANA_ENABLE_COVERAGE)
+    include(CodeCoverage)
+    setup_coverage_target(coverage
+        "${CMAKE_CURRENT_BINARY_DIR}/coverage"
+        "${CMAKE_CURRENT_BINARY_DIR}"
+        "${Boost.Hana_SOURCE_DIR}/include"
+    )
 endif()
 
 if (BOOST_HANA_ENABLE_STRING_UDL)

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -1,0 +1,42 @@
+# Copyright Louis Dionne 2015
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(FATAL_ERROR "Code coverage requires CMAKE_BUILD_TYPE=Debug.")
+endif()
+
+find_program(_lcov lcov)
+if (NOT _lcov)
+  message(FATAL_ERROR "Cannot find lcov")
+endif()
+
+find_program(_genhtml genhtml)
+if (NOT _genhtml)
+  message(FATAL_ERROR "Cannot find genhtml")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+
+function(setup_coverage_target target_name output_dir capture_dirs source_dirs)
+    file(MAKE_DIRECTORY ${output_dir})
+
+    set(_capture_directories "")
+    foreach(dir ${capture_dirs})
+        list(APPEND CAPTURE_DIRS "-d;${dir}")
+    endforeach()
+
+    set(_extract_directories "")
+    foreach(dir ${source_dirs})
+        list(APPEND EXTRACT_DIRS "'${dir}/*'")
+    endforeach()
+
+    add_custom_target(${target_name}
+        COMMAND ${_lcov} --capture ${_capture_directories} -o test_coverage.info
+        COMMAND ${_lcov} --extract test_coverage.info ${_extract_directories} -o test_coverage.info
+        COMMAND ${_genhtml} --demangle-cpp test_coverage.info -o html
+        COMMAND ${CMAKE_COMMAND} -E remove test_coverage.info
+        WORKING_DIRECTORY ${output_dir}
+        COMMENT "Generating test coverage results"
+    )
+endfunction()


### PR DESCRIPTION
This PR is just for exposition. After experimenting around, it turns out that code coverage results are not very useful because Hana is so full of templates. Basically, we trivially end up with nearly 100% coverage, because all the functions that are instantiated are indeed being run. Instead, something more useful would be a tool to check for uninstantiated templates.