### PR TITLE
Provide a sequence optimized for holding types

### DIFF
--- a/benchmark/transform/compile.erb.json
+++ b/benchmark/transform/compile.erb.json
@@ -14,6 +14,9 @@
     {
       "name": "hana::tuple",
       "data": <%= time_compilation('compile.hana.tuple.erb.cpp', hana) %>
+    }, {
+      "name": "hana::types",
+      "data": <%= time_compilation('compile.hana.types.erb.cpp', hana) %>
     }
 
     <% if cmake_bool("@Boost_FOUND@") %>

--- a/benchmark/transform/compile.hana.types.erb.cpp
+++ b/benchmark/transform/compile.hana.types.erb.cpp
@@ -1,0 +1,26 @@
+/*
+@copyright Louis Dionne 2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+ */
+
+#include <boost/hana/experimental/types.hpp>
+#include <boost/hana/transform.hpp>
+#include <boost/hana/type.hpp>
+namespace hana = boost::hana;
+
+
+template <typename>
+struct f { struct type; };
+
+template <int> struct x;
+
+
+int main() {
+    constexpr auto types = hana::experimental::types<
+        <%= (1..input_size).map { |i| "x<#{i}>" }.join(', ') %>
+    >{};
+
+    constexpr auto result = hana::transform(types, hana::metafunction<f>);
+    (void)result;
+}

--- a/include/boost/hana/detail/any_of.hpp
+++ b/include/boost/hana/detail/any_of.hpp
@@ -1,0 +1,46 @@
+/*!
+@file
+Defines `boost::hana::detail::any_of`.
+
+@copyright Louis Dionne 2013-2016
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+ */
+
+#ifndef BOOST_HANA_DETAIL_ANY_OF_HPP
+#define BOOST_HANA_DETAIL_ANY_OF_HPP
+
+#include <boost/hana/config.hpp>
+
+#include <type_traits>
+#include <utility>
+
+
+BOOST_HANA_NAMESPACE_BEGIN namespace detail {
+    std::false_type expand(...);
+
+    template <template <typename ...> class Predicate, typename ...T>
+    decltype(expand(
+        typename std::enable_if<!Predicate<T>::value, void*>::type{}...
+    )) any_of_impl(int);
+
+    template <template <typename ...> class Predicate, typename ...T>
+    std::true_type any_of_impl(...);
+
+    //! @ingroup group-details
+    //! Returns whether the `Predicate` is satisfied by any of the `T...`.
+    //!
+    //! This metafunction will short-circuit the evaluation at the first
+    //! type satisfying the predicate, if such a type exists.
+    //!
+    //!
+    //! @note
+    //! The implementation technique used here was originally shown to
+    //! me by Eric Fiselier. All credits where due.
+    template <template <typename ...> class Predicate, typename ...T>
+    struct any_of
+        : decltype(any_of_impl<Predicate, T...>(int{}))
+    { };
+} BOOST_HANA_NAMESPACE_END
+
+#endif // !BOOST_HANA_DETAIL_ANY_OF_HPP

--- a/include/boost/hana/experimental/types.hpp
+++ b/include/boost/hana/experimental/types.hpp
@@ -1,0 +1,151 @@
+/*!
+@file
+Defines `boost::hana::experimental::types`.
+
+@copyright Louis Dionne 2013-2016
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+ */
+
+#ifndef BOOST_HANA_EXPERIMENTAL_TYPES_HPP
+#define BOOST_HANA_EXPERIMENTAL_TYPES_HPP
+
+#include <boost/hana/bool.hpp>
+#include <boost/hana/concept/metafunction.hpp>
+#include <boost/hana/config.hpp>
+#include <boost/hana/fwd/at.hpp>
+#include <boost/hana/fwd/core/tag_of.hpp>
+#include <boost/hana/fwd/equal.hpp>
+#include <boost/hana/fwd/is_empty.hpp>
+#include <boost/hana/fwd/transform.hpp>
+#include <boost/hana/fwd/unpack.hpp>
+#include <boost/hana/type.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+
+BOOST_HANA_NAMESPACE_BEGIN
+    namespace experimental {
+        //! @ingroup group-datatypes
+        //! @todo
+        template <typename ...T>
+        struct types;
+
+        //! Tag representing a `hana::types` container.
+        //! @relates hana::types
+        struct types_tag;
+
+        //////////////////////////////////////////////////////////////////////
+
+        template <typename ...T>
+        struct types { };
+    } // end namespace experimental
+
+    template <typename ...T>
+    struct tag_of<experimental::types<T...>> {
+        using type = experimental::types_tag;
+    };
+
+    // Foldable
+    template <>
+    struct unpack_impl<hana::experimental::types_tag> {
+        template <typename ...T, typename F, typename = typename std::enable_if<
+            !hana::Metafunction<F>::value
+        >::type>
+        static constexpr decltype(auto) apply(hana::experimental::types<T...> const&, F&& f) {
+            return static_cast<F&&>(f)(hana::type<T>{}...);
+        }
+
+        template <typename ...T, typename F, typename = typename std::enable_if<
+            hana::Metafunction<F>::value
+        >::type>
+        static constexpr hana::type<typename F::template apply<T...>::type>
+        apply(hana::experimental::types<T...> const&, F const&) { return {}; }
+    };
+
+    // Functor
+    template <>
+    struct transform_impl<hana::experimental::types_tag> {
+        template <typename ...T, typename F, typename = typename std::enable_if<
+            !hana::Metafunction<F>::value
+        >::type>
+        static constexpr auto apply(hana::experimental::types<T...> const&, F&& f)
+            -> hana::experimental::types<typename decltype(f(hana::type<T>{}))::type...>
+        { return {}; }
+
+        template <typename ...T, typename F, typename = typename std::enable_if<
+            hana::Metafunction<F>::value
+        >::type>
+        static constexpr hana::experimental::types<typename F::template apply<T>::type...>
+        apply(hana::experimental::types<T...> const&, F const&) { return {}; }
+    };
+
+    namespace types_detail {
+        template <std::size_t I, typename T>
+        struct elt { using type = T; };
+
+        template <typename Indices, typename ...T>
+        struct indexer;
+
+        template <std::size_t ...I, typename ...T>
+        struct indexer<std::index_sequence<I...>, T...>
+            : elt<I, T>...
+        { };
+
+        template <std::size_t I, typename T>
+        elt<I, T> get_elt(elt<I, T> const&);
+    }
+
+    // Iterable
+    template <>
+    struct at_impl<hana::experimental::types_tag> {
+        template <typename ...T, typename N>
+        static constexpr auto
+        apply(hana::experimental::types<T...> const&, N const&) {
+            using Indexer = types_detail::indexer<std::make_index_sequence<sizeof...(T)>, T...>;
+            using Nth = typename decltype(types_detail::get_elt<N::value>(Indexer{}))::type;
+            return hana::type<Nth>{};
+        }
+    };
+
+    template <>
+    struct is_empty_impl<hana::experimental::types_tag> {
+        template <typename ...T>
+        static constexpr hana::bool_<sizeof...(T) == 0>
+        apply(hana::experimental::types<T...> const&)
+        { return {}; }
+    };
+
+    template <>
+    struct drop_front_impl<hana::experimental::types_tag> {
+        template <std::size_t n, typename Indexer, std::size_t ...i>
+        static hana::experimental::types<
+            typename decltype(types_detail::get_elt<i + n>(Indexer{}))::type...
+        > helper(std::index_sequence<i...>);
+
+        template <typename ...T, typename N>
+        static constexpr auto
+        apply(hana::experimental::types<T...> const&, N const&) {
+            constexpr std::size_t n = N::value > sizeof...(T) ? sizeof...(T) : N::value;
+            using Indices = std::make_index_sequence<sizeof...(T) - n>;
+            using Indexer = types_detail::indexer<std::make_index_sequence<sizeof...(T)>, T...>;
+            return decltype(helper<n, Indexer>(Indices{})){};
+        }
+    };
+
+    // Comparable
+    template <>
+    struct equal_impl<hana::experimental::types_tag, hana::experimental::types_tag> {
+        template <typename Types>
+        static constexpr hana::true_ apply(Types const&, Types const&)
+        { return {}; }
+
+        template <typename Ts, typename Us>
+        static constexpr hana::false_ apply(Ts const&, Us const&)
+        { return {}; }
+    };
+BOOST_HANA_NAMESPACE_END
+
+#endif // !BOOST_HANA_EXPERIMENTAL_TYPES_HPP

--- a/include/boost/hana/experimental/types.hpp
+++ b/include/boost/hana/experimental/types.hpp
@@ -13,7 +13,9 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/bool.hpp>
 #include <boost/hana/concept/metafunction.hpp>
 #include <boost/hana/config.hpp>
+#include <boost/hana/detail/any_of.hpp>
 #include <boost/hana/fwd/at.hpp>
+#include <boost/hana/fwd/contains.hpp>
 #include <boost/hana/fwd/core/tag_of.hpp>
 #include <boost/hana/fwd/equal.hpp>
 #include <boost/hana/fwd/is_empty.hpp>
@@ -133,6 +135,27 @@ BOOST_HANA_NAMESPACE_BEGIN
             using Indexer = types_detail::indexer<std::make_index_sequence<sizeof...(T)>, T...>;
             return decltype(helper<n, Indexer>(Indices{})){};
         }
+    };
+
+    // Searchable
+    template <>
+    struct contains_impl<hana::experimental::types_tag> {
+        template <typename U>
+        struct is_same_as {
+            template <typename T>
+            struct apply {
+                static constexpr bool value = std::is_same<U, T>::value;
+            };
+        };
+
+        template <typename ...T, typename U>
+        static constexpr auto apply(hana::experimental::types<T...> const&, U const&)
+            -> hana::bool_<
+                detail::any_of<is_same_as<typename U::type>::template apply, T...>::value
+            >
+        { return {}; }
+
+        static constexpr hana::false_ apply(...) { return {}; }
     };
 
     // Comparable

--- a/test/detail/any_of.cpp
+++ b/test/detail/any_of.cpp
@@ -1,0 +1,45 @@
+// Copyright Louis Dionne 2013-2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/detail/any_of.hpp>
+#include <boost/hana/detail/wrong.hpp>
+#include <boost/hana/integral_constant.hpp>
+namespace hana = boost::hana;
+
+
+template <typename I>
+struct is_even {
+    static constexpr bool value = I::value % 2 == 0;
+};
+
+
+static_assert(!hana::detail::any_of<is_even>::value, "");
+static_assert(!hana::detail::any_of<is_even, hana::int_<1>>::value, "");
+static_assert(!hana::detail::any_of<is_even, hana::int_<1>, hana::int_<3>>::value, "");
+static_assert(!hana::detail::any_of<is_even, hana::int_<1>, hana::int_<3>, hana::int_<5>>::value, "");
+static_assert(!hana::detail::any_of<is_even, hana::int_<1>, hana::int_<3>, hana::int_<5>, hana::int_<7>>::value, "");
+
+static_assert(hana::detail::any_of<is_even, hana::int_<0>>::value, "");
+static_assert(hana::detail::any_of<is_even, hana::int_<0>, hana::int_<2>>::value, "");
+static_assert(hana::detail::any_of<is_even, hana::int_<0>, hana::int_<2>, hana::int_<4>>::value, "");
+static_assert(hana::detail::any_of<is_even, hana::int_<0>, hana::int_<2>, hana::int_<4>, hana::int_<6>>::value, "");
+
+static_assert(hana::detail::any_of<is_even, hana::int_<0>, hana::int_<1>>::value, "");
+static_assert(hana::detail::any_of<is_even, hana::int_<0>, hana::int_<1>, hana::int_<2>>::value, "");
+static_assert(hana::detail::any_of<is_even, hana::int_<0>, hana::int_<1>, hana::int_<2>, hana::int_<3>>::value, "");
+static_assert(hana::detail::any_of<is_even, hana::int_<0>, hana::int_<1>, hana::int_<2>, hana::int_<3>, hana::int_<4>>::value, "");
+static_assert(hana::detail::any_of<is_even, hana::int_<1>, hana::int_<3>, hana::int_<5>, hana::int_<8>>::value, "");
+static_assert(hana::detail::any_of<is_even, hana::int_<1>, hana::int_<8>, hana::int_<5>, hana::int_<7>>::value, "");
+
+// Make sure we short-circuit properly
+template <typename ...Dummy>
+struct fail {
+    static_assert(hana::detail::wrong<Dummy...>{},
+        "this must never be instantiated");
+};
+static_assert(hana::detail::any_of<is_even, hana::int_<1>, hana::int_<2>, fail<>>::value, "");
+static_assert(hana::detail::any_of<is_even, hana::int_<1>, hana::int_<2>, fail<>, hana::int_<3>>::value, "");
+static_assert(hana::detail::any_of<is_even, hana::int_<1>, hana::int_<2>, fail<>, hana::int_<4>>::value, "");
+
+int main() { }

--- a/test/experimental/types/at.cpp
+++ b/test/experimental/types/at.cpp
@@ -1,0 +1,80 @@
+// Copyright Louis Dionne 2013-2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/at.hpp>
+#include <boost/hana/equal.hpp>
+#include <boost/hana/experimental/types.hpp>
+#include <boost/hana/type.hpp>
+namespace hana = boost::hana;
+
+
+template <int> struct x;
+
+int main() {
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<0>(hana::experimental::types<x<0>>{}),
+        hana::type_c<x<0>>
+    ));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<0>(hana::experimental::types<x<0>, x<1>>{}),
+        hana::type_c<x<0>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<1>(hana::experimental::types<x<0>, x<1>>{}),
+        hana::type_c<x<1>>
+    ));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<0>(hana::experimental::types<x<0>, x<1>, x<2>>{}),
+        hana::type_c<x<0>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<1>(hana::experimental::types<x<0>, x<1>, x<2>>{}),
+        hana::type_c<x<1>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<2>(hana::experimental::types<x<0>, x<1>, x<2>>{}),
+        hana::type_c<x<2>>
+    ));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<0>(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}),
+        hana::type_c<x<0>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<1>(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}),
+        hana::type_c<x<1>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<2>(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}),
+        hana::type_c<x<2>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<3>(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}),
+        hana::type_c<x<3>>
+    ));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<0>(hana::experimental::types<x<0>, x<1>, x<2>, x<3>, x<4>>{}),
+        hana::type_c<x<0>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<1>(hana::experimental::types<x<0>, x<1>, x<2>, x<3>, x<4>>{}),
+        hana::type_c<x<1>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<2>(hana::experimental::types<x<0>, x<1>, x<2>, x<3>, x<4>>{}),
+        hana::type_c<x<2>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<3>(hana::experimental::types<x<0>, x<1>, x<2>, x<3>, x<4>>{}),
+        hana::type_c<x<3>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::at_c<4>(hana::experimental::types<x<0>, x<1>, x<2>, x<3>, x<4>>{}),
+        hana::type_c<x<4>>
+    ));
+}

--- a/test/experimental/types/contains.cpp
+++ b/test/experimental/types/contains.cpp
@@ -1,0 +1,81 @@
+// Copyright Louis Dionne 2013-2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/contains.hpp>
+#include <boost/hana/experimental/types.hpp>
+#include <boost/hana/not.hpp>
+#include <boost/hana/type.hpp>
+namespace hana = boost::hana;
+
+
+template <int> struct x;
+struct undefined { };
+
+int main() {
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::contains(
+        hana::experimental::types<>{},
+        undefined{}
+    )));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::contains(
+        hana::experimental::types<x<0>>{},
+        hana::type_c<x<0>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::contains(
+        hana::experimental::types<x<0>>{},
+        hana::type_c<x<999>>
+    )));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::contains(
+        hana::experimental::types<x<0>, x<1>>{},
+        hana::type_c<x<0>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::contains(
+        hana::experimental::types<x<0>, x<1>>{},
+        hana::type_c<x<1>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::contains(
+        hana::experimental::types<x<0>, x<1>>{},
+        hana::type_c<x<999>>
+    )));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::contains(
+        hana::experimental::types<x<0>, x<1>, x<2>>{},
+        hana::type_c<x<0>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::contains(
+        hana::experimental::types<x<0>, x<1>, x<2>>{},
+        hana::type_c<x<1>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::contains(
+        hana::experimental::types<x<0>, x<1>, x<2>>{},
+        hana::type_c<x<2>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::contains(
+        hana::experimental::types<x<0>, x<1>, x<2>>{},
+        hana::type_c<x<999>>
+    )));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::contains(
+        hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{},
+        hana::type_c<x<0>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::contains(
+        hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{},
+        hana::type_c<x<1>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::contains(
+        hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{},
+        hana::type_c<x<2>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::contains(
+        hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{},
+        hana::type_c<x<3>>
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::contains(
+        hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{},
+        hana::type_c<x<999>>
+    )));
+}

--- a/test/experimental/types/drop_front.cpp
+++ b/test/experimental/types/drop_front.cpp
@@ -1,0 +1,100 @@
+// Copyright Louis Dionne 2013-2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/drop_front.hpp>
+#include <boost/hana/equal.hpp>
+#include <boost/hana/experimental/types.hpp>
+#include <boost/hana/integral_constant.hpp>
+namespace hana = boost::hana;
+
+
+template <int> struct x;
+
+int main() {
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<>{}, hana::size_c<0>),
+        hana::experimental::types<>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<>{}, hana::size_c<1>),
+        hana::experimental::types<>{}
+    ));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>>{}, hana::size_c<0>),
+        hana::experimental::types<x<0>>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>>{}, hana::size_c<1>),
+        hana::experimental::types<>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>>{}, hana::size_c<2>),
+        hana::experimental::types<>{}
+    ));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>>{}, hana::size_c<0>),
+        hana::experimental::types<x<0>, x<1>>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>>{}, hana::size_c<1>),
+        hana::experimental::types<x<1>>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>>{}, hana::size_c<2>),
+        hana::experimental::types<>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>>{}, hana::size_c<3>),
+        hana::experimental::types<>{}
+    ));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>, x<2>>{}, hana::size_c<0>),
+        hana::experimental::types<x<0>, x<1>, x<2>>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>, x<2>>{}, hana::size_c<1>),
+        hana::experimental::types<x<1>, x<2>>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>, x<2>>{}, hana::size_c<2>),
+        hana::experimental::types<x<2>>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>, x<2>>{}, hana::size_c<3>),
+        hana::experimental::types<>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>, x<2>>{}, hana::size_c<4>),
+        hana::experimental::types<>{}
+    ));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}, hana::size_c<0>),
+        hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}, hana::size_c<1>),
+        hana::experimental::types<x<1>, x<2>, x<3>>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}, hana::size_c<2>),
+        hana::experimental::types<x<2>, x<3>>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}, hana::size_c<3>),
+        hana::experimental::types<x<3>>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}, hana::size_c<4>),
+        hana::experimental::types<>{}
+    ));
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::drop_front(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}, hana::size_c<5>),
+        hana::experimental::types<>{}
+    ));
+}

--- a/test/experimental/types/equal.cpp
+++ b/test/experimental/types/equal.cpp
@@ -1,0 +1,59 @@
+// Copyright Louis Dionne 2013-2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/equal.hpp>
+#include <boost/hana/experimental/types.hpp>
+#include <boost/hana/not.hpp>
+namespace hana = boost::hana;
+
+
+template <int> struct x;
+
+int main() {
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::experimental::types<>{},
+        hana::experimental::types<>{}
+    ));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::experimental::types<x<0>>{},
+        hana::experimental::types<x<0>>{}
+    ));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::experimental::types<x<0>, x<1>, x<2>>{},
+        hana::experimental::types<x<0>, x<1>, x<2>>{}
+    ));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::equal(
+        hana::experimental::types<>{},
+        hana::experimental::types<x<0>>{}
+    )));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::equal(
+        hana::experimental::types<x<0>>{},
+        hana::experimental::types<>{}
+    )));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::equal(
+        hana::experimental::types<x<0>>{},
+        hana::experimental::types<x<1>>{}
+    )));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::equal(
+        hana::experimental::types<x<0>, x<1>, x<2>>{},
+        hana::experimental::types<x<0>, x<1>, x<3>>{}
+    )));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::equal(
+        hana::experimental::types<x<0>, x<1>, x<2>>{},
+        hana::experimental::types<x<0>, x<1>>{}
+    )));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::equal(
+        hana::experimental::types<x<0>, x<1>, x<2>>{},
+        hana::experimental::types<x<0>, x<9>, x<2>>{}
+    )));
+}

--- a/test/experimental/types/is_empty.cpp
+++ b/test/experimental/types/is_empty.cpp
@@ -1,0 +1,34 @@
+// Copyright Louis Dionne 2013-2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/experimental/types.hpp>
+#include <boost/hana/is_empty.hpp>
+#include <boost/hana/not.hpp>
+namespace hana = boost::hana;
+
+
+template <int> struct x;
+
+int main() {
+    BOOST_HANA_CONSTANT_CHECK(hana::is_empty(
+        hana::experimental::types<>{}
+    ));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::is_empty(
+        hana::experimental::types<x<0>>{}
+    )));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::is_empty(
+        hana::experimental::types<x<0>, x<1>>{}
+    )));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::is_empty(
+        hana::experimental::types<x<0>, x<1>, x<2>>{}
+    )));
+
+    BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::is_empty(
+        hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}
+    )));
+}

--- a/test/experimental/types/transform.cpp
+++ b/test/experimental/types/transform.cpp
@@ -1,0 +1,74 @@
+// Copyright Louis Dionne 2013-2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/equal.hpp>
+#include <boost/hana/experimental/types.hpp>
+#include <boost/hana/transform.hpp>
+#include <boost/hana/type.hpp>
+namespace hana = boost::hana;
+
+
+template <typename ...>
+struct mf { struct type; };
+
+template <int> struct x;
+struct undefined { };
+
+int main() {
+    BOOST_HANA_CONSTANT_CHECK(hana::equal(
+        hana::transform(hana::experimental::types<>{}, undefined{}),
+        hana::experimental::types<>{}
+    ));
+
+    // with a Metafunction
+    {
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::transform(hana::experimental::types<x<0>>{}, hana::metafunction<mf>),
+            hana::experimental::types<mf<x<0>>::type>{}
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::transform(hana::experimental::types<x<0>, x<1>>{}, hana::metafunction<mf>),
+            hana::experimental::types<mf<x<0>>::type, mf<x<1>>::type>{}
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::transform(hana::experimental::types<x<0>, x<1>, x<2>>{}, hana::metafunction<mf>),
+            hana::experimental::types<mf<x<0>>::type, mf<x<1>>::type, mf<x<2>>::type>{}
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::transform(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}, hana::metafunction<mf>),
+            hana::experimental::types<mf<x<0>>::type, mf<x<1>>::type, mf<x<2>>::type, mf<x<3>>::type>{}
+        ));
+    }
+
+    // with a non-Metafunction
+    {
+        auto f = [](auto t) {
+            return hana::metafunction<mf>(t);
+        };
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::transform(hana::experimental::types<x<0>>{}, f),
+            hana::experimental::types<mf<x<0>>::type>{}
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::transform(hana::experimental::types<x<0>, x<1>>{}, f),
+            hana::experimental::types<mf<x<0>>::type, mf<x<1>>::type>{}
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::transform(hana::experimental::types<x<0>, x<1>, x<2>>{}, f),
+            hana::experimental::types<mf<x<0>>::type, mf<x<1>>::type, mf<x<2>>::type>{}
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::transform(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}, f),
+            hana::experimental::types<mf<x<0>>::type, mf<x<1>>::type, mf<x<2>>::type, mf<x<3>>::type>{}
+        ));
+    }
+}

--- a/test/experimental/types/unpack.cpp
+++ b/test/experimental/types/unpack.cpp
@@ -1,0 +1,83 @@
+// Copyright Louis Dionne 2013-2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/equal.hpp>
+#include <boost/hana/experimental/types.hpp>
+#include <boost/hana/type.hpp>
+#include <boost/hana/unpack.hpp>
+
+#include <laws/base.hpp>
+namespace hana = boost::hana;
+
+
+template <typename ...>
+struct mf { struct type; };
+
+template <int> struct x;
+
+int main() {
+    // with a Metafunction
+    {
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(hana::experimental::types<>{}, hana::metafunction<mf>),
+            hana::type_c<mf<>::type>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(hana::experimental::types<x<0>>{}, hana::metafunction<mf>),
+            hana::type_c<mf<x<0>>::type>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(hana::experimental::types<x<0>, x<1>>{}, hana::metafunction<mf>),
+            hana::type_c<mf<x<0>, x<1>>::type>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(hana::experimental::types<x<0>, x<1>, x<2>>{}, hana::metafunction<mf>),
+            hana::type_c<mf<x<0>, x<1>, x<2>>::type>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}, hana::metafunction<mf>),
+            hana::type_c<mf<x<0>, x<1>, x<2>, x<3>>::type>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(hana::experimental::types<x<0>, x<1>, x<2>, x<3>, x<4>>{}, hana::metafunction<mf>),
+            hana::type_c<mf<x<0>, x<1>, x<2>, x<3>, x<4>>::type>
+        ));
+    }
+
+    // with a non-Metafunction
+    {
+        auto f = hana::test::_injection<0>{};
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(hana::experimental::types<>{}, f),
+            f()
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(hana::experimental::types<x<0>>{}, f),
+            f(hana::type_c<x<0>>)
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(hana::experimental::types<x<0>, x<1>>{}, f),
+            f(hana::type_c<x<0>>, hana::type_c<x<1>>)
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(hana::experimental::types<x<0>, x<1>, x<2>>{}, f),
+            f(hana::type_c<x<0>>, hana::type_c<x<1>>, hana::type_c<x<2>>)
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(hana::experimental::types<x<0>, x<1>, x<2>, x<3>>{}, f),
+            f(hana::type_c<x<0>>, hana::type_c<x<1>>, hana::type_c<x<2>>, hana::type_c<x<3>>)
+        ));
+    }
+}


### PR DESCRIPTION
In its current form, Hana cannot easily compete (in terms of compile-time performance) against pure type-level metaprogramming libraries that provide sequences holding types only. This is because `hana::tuple` does so much more than holding types only, and the compiler just has more work to do.

I think the remedy to this is to provide a sequence optimized for holding types only. This way, one would retain the expressive power of Hana, while providing compile-times that are very close to pure type-level sequences. This pull request explores such a sequence.