### PR TITLE
Documentation/operators

### DIFF
--- a/include/boost/hana/fwd/integral_constant.hpp
+++ b/include/boost/hana/fwd/integral_constant.hpp
@@ -89,7 +89,6 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! - Bitwise: `~`, `&`, `|`, `^`, `<<`, `>>`
     //! - Comparison: `==`, `!=`, `<`, `<=`, `>`, `>=`
     //! - %Logical: `||`, `&&`, `!`
-    //! - Member access: `*` (dereference)
     //!
     //!
     //! Construction with user-defined literals
@@ -169,6 +168,66 @@ BOOST_HANA_NAMESPACE_BEGIN
         static constexpr void times(F&& f) {
             f(); f(); ... f(); // n times total
         }
+
+        //! Equivalent to hana::plus
+        template <typename X, typename Y>
+        friend constexpr auto operator+(X&& x, Y&& y);
+
+        //! Equivalent to hana::minux
+        template <typename X, typename Y>
+        friend constexpr auto operator-(X&& x, Y&& y);
+
+        //! Equivalent to hana::negate
+        template <typename X>
+        friend constexpr auto operator-(X&& x);
+
+        //! Equivalent to hana::mult
+        template <typename X, typename Y>
+        friend constexpr auto operator*(X&& x, Y&& y);
+
+        //! Equivalent to hana::div
+        template <typename X, typename Y>
+        friend constexpr auto operator/(X&& x, Y&& y);
+
+        //! Equivalent to hana::mod
+        template <typename X, typename Y>
+        friend constexpr auto operator%(X&& x, Y&& y);
+
+        //! Equivalent to `hana::equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator==(X&& x, Y&& y);
+
+        //! Equivalent to `hana::not_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator!=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::or_`
+        template <typename X, typename Y>
+        friend constexpr auto operator||(X&& x, Y&& y);
+
+        //! Equivalent to `hana::and_`
+        template <typename X, typename Y>
+        friend constexpr auto operator&&(X&& x, Y&& y);
+
+        //! Equivalent to `hana::not_`
+        template <typename X>
+        friend constexpr auto operator!(X&& x);
+
+        //! Equivalent to `hana::less`
+        template <typename X, typename Y>
+        friend constexpr auto operator<(X&& x, Y&& y);
+
+        //! Equivalent to `hana::greater`
+        template <typename X, typename Y>
+        friend constexpr auto operator>(X&& x, Y&& y);
+
+        //! Equivalent to `hana::less_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator<=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::greater_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator>=(X&& x, Y&& y);
     };
 #else
     template <typename T, T v>

--- a/include/boost/hana/fwd/lazy.hpp
+++ b/include/boost/hana/fwd/lazy.hpp
@@ -68,7 +68,11 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! [1]: http://ldionne.com/2015/03/16/laziness-as-a-comonad
 #ifdef BOOST_HANA_DOXYGEN_INVOKED
     template <typename ...>
-    struct lazy;
+    struct lazy {
+        //! Equivalent to `hana::chain`.
+        template <typename ...T, typename F>
+        friend constexpr auto operator|(lazy<T...>, F);
+    };
 #else
     // We do not _actually_ define the lazy<...> type. Per the documentation,
     // users can't rely on it being anything, and so they should never use

--- a/include/boost/hana/fwd/map.hpp
+++ b/include/boost/hana/fwd/map.hpp
@@ -76,6 +76,18 @@ BOOST_HANA_NAMESPACE_BEGIN
         //! Move-construct a map from another map. This constructor only
         //! exists when all the elements of the map are move-constructible.
         constexpr map(map&& other) = default;
+
+        //! Equivalent to `hana::equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator==(X&& x, Y&& y);
+
+        //! Equivalent to `hana::not_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator!=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::at_key`
+        template <typename Key>
+        constexpr decltype(auto) operator[](Key&& key);
     };
 #else
     template <typename ...Pairs>

--- a/include/boost/hana/fwd/optional.hpp
+++ b/include/boost/hana/fwd/optional.hpp
@@ -252,6 +252,34 @@ BOOST_HANA_NAMESPACE_BEGIN
         //! @include example/optional/value_or.cpp
         template <typename U>
         constexpr decltype(auto) value_or(U&& default_);
+
+        //! Equivalent to `hana::chain`.
+        template <typename ...T, typename F>
+        friend constexpr auto operator|(optional<T...>, F);
+
+        //! Equivalent to `hana::equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator==(X&& x, Y&& y);
+
+        //! Equivalent to `hana::not_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator!=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::less`
+        template <typename X, typename Y>
+        friend constexpr auto operator<(X&& x, Y&& y);
+
+        //! Equivalent to `hana::greater`
+        template <typename X, typename Y>
+        friend constexpr auto operator>(X&& x, Y&& y);
+
+        //! Equivalent to `hana::less_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator<=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::greater_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator>=(X&& x, Y&& y);
     };
 #else
     template <typename ...>

--- a/include/boost/hana/fwd/pair.hpp
+++ b/include/boost/hana/fwd/pair.hpp
@@ -91,6 +91,30 @@ BOOST_HANA_NAMESPACE_BEGIN
         //! element in the source pair.
         template <typename T, typename U>
         constexpr pair& operator=(pair<T, U>&& other);
+
+        //! Equivalent to `hana::equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator==(X&& x, Y&& y);
+
+        //! Equivalent to `hana::not_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator!=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::less`
+        template <typename X, typename Y>
+        friend constexpr auto operator<(X&& x, Y&& y);
+
+        //! Equivalent to `hana::greater`
+        template <typename X, typename Y>
+        friend constexpr auto operator>(X&& x, Y&& y);
+
+        //! Equivalent to `hana::less_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator<=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::greater_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator>=(X&& x, Y&& y);
     };
 #else
     template <typename First, typename Second>

--- a/include/boost/hana/fwd/range.hpp
+++ b/include/boost/hana/fwd/range.hpp
@@ -16,6 +16,7 @@ Distributed under the Boost Software License, Version 1.0.
 
 
 BOOST_HANA_NAMESPACE_BEGIN
+#ifdef BOOST_HANA_DOXYGEN_INVOKED
     //! @ingroup group-datatypes
     //! Compile-time half-open interval of `hana::integral_constant`s.
     //!
@@ -62,7 +63,23 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! in the range `[from, to)`, but it is much more compile-time efficient.
     //! @include example/range/searchable.cpp
     template <typename T, T from, T to>
+    struct range {
+        //! Equivalent to `hana::equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator==(X&& x, Y&& y);
+
+        //! Equivalent to `hana::not_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator!=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::at`
+        template <typename N>
+        constexpr decltype(auto) operator[](N&& n);
+    };
+#else
+    template <typename T, T from, T to>
     struct range;
+#endif
 
     //! Tag representing a `hana::range`.
     //! @relates hana::range

--- a/include/boost/hana/fwd/set.hpp
+++ b/include/boost/hana/fwd/set.hpp
@@ -77,6 +77,18 @@ BOOST_HANA_NAMESPACE_BEGIN
         //! Move-construct a set from another set. This constructor only
         //! exists when all the elements of the set are move-constructible.
         constexpr set(set&& other) = default;
+
+        //! Equivalent to `hana::equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator==(X&& x, Y&& y);
+
+        //! Equivalent to `hana::not_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator!=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::at_key`
+        template <typename Key>
+        constexpr decltype(auto) operator[](Key&& key);
     };
 #else
     template <typename ...Xs>

--- a/include/boost/hana/fwd/string.hpp
+++ b/include/boost/hana/fwd/string.hpp
@@ -15,6 +15,7 @@ Distributed under the Boost Software License, Version 1.0.
 
 
 BOOST_HANA_NAMESPACE_BEGIN
+#ifdef BOOST_HANA_DOXYGEN_INVOKED
     //! @ingroup group-datatypes
     //! Compile-time string.
     //!
@@ -93,7 +94,39 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! > container type like `std::string_view` would be great, but that's
     //! > a bit complicated for the time being.
     template <char ...s>
+    struct string {
+        //! Equivalent to `hana::equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator==(X&& x, Y&& y);
+
+        //! Equivalent to `hana::not_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator!=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::less`
+        template <typename X, typename Y>
+        friend constexpr auto operator<(X&& x, Y&& y);
+
+        //! Equivalent to `hana::greater`
+        template <typename X, typename Y>
+        friend constexpr auto operator>(X&& x, Y&& y);
+
+        //! Equivalent to `hana::less_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator<=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::greater_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator>=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::at`
+        template <typename N>
+        constexpr decltype(auto) operator[](N&& n);
+    };
+#else
+    template <char ...s>
     struct string;
+#endif
 
     //! Tag representing a compile-time string.
     //! @relates hana::string

--- a/include/boost/hana/fwd/tuple.hpp
+++ b/include/boost/hana/fwd/tuple.hpp
@@ -111,6 +111,38 @@ BOOST_HANA_NAMESPACE_BEGIN
         //! corresponding element in the source tuple.
         template <typename ...Yn>
         constexpr tuple& operator=(tuple<Yn...>&& other);
+
+        //! Equivalent to `hana::chain`.
+        template <typename ...T, typename F>
+        friend constexpr auto operator|(tuple<T...>, F);
+
+        //! Equivalent to `hana::equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator==(X&& x, Y&& y);
+
+        //! Equivalent to `hana::not_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator!=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::less`
+        template <typename X, typename Y>
+        friend constexpr auto operator<(X&& x, Y&& y);
+
+        //! Equivalent to `hana::greater`
+        template <typename X, typename Y>
+        friend constexpr auto operator>(X&& x, Y&& y);
+
+        //! Equivalent to `hana::less_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator<=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::greater_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator>=(X&& x, Y&& y);
+
+        //! Equivalent to `hana::at`
+        template <typename N>
+        constexpr decltype(auto) operator[](N&& n);
     };
 #else
     template <typename ...Xn>

--- a/include/boost/hana/fwd/type.hpp
+++ b/include/boost/hana/fwd/type.hpp
@@ -51,6 +51,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! @endcode
     //!
     //!
+    //! @anchor type_lvalues_and_rvalues
     //! Lvalues and rvalues
     //! -------------------
     //! When storing `type`s in heterogeneous containers, some algorithms
@@ -82,7 +83,19 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! @include example/type/comparable.cpp
 #ifdef BOOST_HANA_DOXYGEN_INVOKED
     template <typename T>
-    struct type;
+    struct type {
+        //! Returns rvalue of self.
+        //! See @ref type_lvalues_and_rvalues "description".
+        constexpr auto operator+() const;
+
+        //! Equivalent to `hana::equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator==(X&& x, Y&& y);
+
+        //! Equivalent to `hana::not_equal`
+        template <typename X, typename Y>
+        friend constexpr auto operator!=(X&& x, Y&& y);
+    };
 #else
     template <typename T>
     struct type_impl;


### PR DESCRIPTION
There are two things to note here:

1. I took the liberty of removing documentation of a pointer operand for `integral_constant` because I think it no longer exists. It is in a separate commit just in case.

2. For the data-types that I added a documentation definition to, for some reason the "Public Members" documentation is not full width, and I could not find any reason just by looking at the style rules. I could possibly add a style rule unless I am missing something obvious with this.