### PR TITLE
[issue] add default cnstr to reverse_partial_t

### DIFF
--- a/include/boost/hana/functional/reverse_partial.hpp
+++ b/include/boost/hana/functional/reverse_partial.hpp
@@ -62,6 +62,10 @@ BOOST_HANA_NAMESPACE_BEGIN
 
     template <std::size_t ...n, typename F, typename ...X>
     struct reverse_partial_t<std::index_sequence<n...>, F, X...> {
+        // Not needed in theory; workaround for a bug in libstdc++'s tuple,
+        // which instantiates the default constructor of elements too eagerly.
+        reverse_partial_t() = default;
+
         template <typename ...T>
         constexpr reverse_partial_t(make_reverse_partial_t::secret, T&& ...t)
             : storage_{static_cast<T&&>(t)...}

--- a/test/issues/github_260.cpp
+++ b/test/issues/github_260.cpp
@@ -1,0 +1,27 @@
+// Copyright Jason Rice 2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include<boost/hana/functional/partial.hpp>
+#include<boost/hana/functional/reverse_partial.hpp>
+#include<boost/hana/equal.hpp>
+#include<boost/hana/type.hpp>
+#include<boost/hana/integral_constant.hpp>
+namespace hana = boost::hana;
+
+template <typename T1, typename T2>
+struct test_t { };
+constexpr auto test = hana::template_<test_t>;
+
+int main() {
+  {
+    using F = decltype(hana::partial(test, hana::int_c<1>));
+    constexpr F f{};
+    static_assert(f(hana::int_c<2>) == test(hana::int_c<1>, hana::int_c<2>), "");
+  }
+  {
+    using F = decltype(hana::reverse_partial(test, hana::int_c<2>));
+    constexpr F f{};
+    static_assert(f(hana::int_c<1>) == test(hana::int_c<1>, hana::int_c<2>), "");
+  }
+}


### PR DESCRIPTION
This PR is to help with #260.

Note that I copied the comment from the implementation of `partial_t`, though I wouldn't expect a default constructor to be implicitly provided in the presence of a user-declared constructor. I'm not really sure what it is saying.