### PR TITLE
Allow overload_linearly to be called with a single argument.

### DIFF
--- a/include/boost/hana/functional/overload_linearly.hpp
+++ b/include/boost/hana/functional/overload_linearly.hpp
@@ -96,6 +96,11 @@ BOOST_HANA_NAMESPACE_BEGIN
             return (*this)(static_cast<F&&>(f),
                     (*this)(static_cast<G&&>(g), static_cast<H&&>(h)...));
         }
+
+        template <typename F>
+        constexpr decltype(auto) operator()(F&& f) const {
+            return static_cast<F&&>(f);
+        }
     };
 
     constexpr make_overload_linearly_t overload_linearly{};


### PR DESCRIPTION
The unary call simply returns the passed function. Fixes issue #280.