### PR TITLE
[overload_linearly] Allow `overload_linearly` to be called with a single argument

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,12 +54,9 @@ install:
   - cmake --version
 
   ############################################################################
-  # Install a pre-built Clang-cl
+  # Setup the path to Clang-cl
   ############################################################################
-  - set LLVM_URL="https://www.dropbox.com/s/caol8ihddfwqs31/LLVM-3.7.0-win64.zip?dl=1"
-  - appveyor DownloadFile %LLVM_URL% -FileName llvm.zip
-  - 7z x llvm.zip -oC:\projects\deps\llvm > nul
-  - set PATH=C:\projects\deps\llvm\bin;%PATH%
+  - set PATH="C:\Program Files\LLVM\bin";%PATH%
   - clang-cl -v
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,9 +77,9 @@ matrix:
     - env: UNIT_TESTS=true COMPILER=clang++-3.8 BOOST_VERSION=default CMAKE_OPTIONS="-DBOOST_HANA_ENABLE_MEMCHECK=ON"
 
     # Xcode 6.3
-    - os: osx
-      env: UNIT_TESTS=true COMPILER=clang++ BOOST_VERSION=default
-      osx_image: beta-xcode6.3
+    # - os: osx
+    #   env: UNIT_TESTS=true COMPILER=clang++ BOOST_VERSION=default
+    #   osx_image: beta-xcode6.3
 
     # Xcode 6.4
     - os: osx

--- a/include/boost/hana/functional/overload_linearly.hpp
+++ b/include/boost/hana/functional/overload_linearly.hpp
@@ -11,6 +11,7 @@ Distributed under the Boost Software License, Version 1.0.
 #define BOOST_HANA_FUNCTIONAL_OVERLOAD_LINEARLY_HPP
 
 #include <boost/hana/config.hpp>
+#include <boost/hana/detail/decay.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -98,7 +99,7 @@ BOOST_HANA_NAMESPACE_BEGIN
         }
 
         template <typename F>
-        constexpr decltype(auto) operator()(F&& f) const {
+        constexpr typename detail::decay<F>::type operator()(F&& f) const {
             return static_cast<F&&>(f);
         }
     };

--- a/include/boost/hana/functional/overload_linearly.hpp
+++ b/include/boost/hana/functional/overload_linearly.hpp
@@ -96,6 +96,11 @@ BOOST_HANA_NAMESPACE_BEGIN
             return (*this)(static_cast<F&&>(f),
                     (*this)(static_cast<G&&>(g), static_cast<H&&>(h)...));
         }
+
+        template <typename F>
+        constexpr decltype(auto) operator()(F&& f) const {
+            return static_cast<F&&>(f);
+        }
     };
 
     constexpr make_overload_linearly_t overload_linearly{};

--- a/test/functional/overload_linearly.cpp
+++ b/test/functional/overload_linearly.cpp
@@ -102,4 +102,21 @@ int main() {
             test::ct_eq<2>{}
         ));
     }
+
+    // 1 function (github issue #280)
+    {
+        auto f = overload_linearly(
+            [](A) { return test::ct_eq<0>{}; }
+        );
+
+        BOOST_HANA_CONSTANT_CHECK(equal(
+            f(A{}),
+            test::ct_eq<0>{}
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(equal(
+            f(AA{}),
+            f(A{})
+        ));
+    }
 }


### PR DESCRIPTION
Fixes #280.

> [overload_linearly] Allow `overload_linearly` to be called with a single argument
>
> - Added an `make_overload_linearly_t::operator()` overload that takes a single argument, and simply > returns the argument

*(I closed the previous pull request because I completely forgot to create a new branch.)*