### PR TITLE
Use detail::decay instead of std::decay in implementation

### DIFF
--- a/include/boost/hana/basic_tuple.hpp
+++ b/include/boost/hana/basic_tuple.hpp
@@ -150,7 +150,7 @@ BOOST_HANA_NAMESPACE_BEGIN
 
         // copy constructor
         template <typename Other, typename = typename std::enable_if<
-            std::is_same<typename std::decay<Other>::type, basic_tuple>::value
+            std::is_same<typename detail::decay<Other>::type, basic_tuple>::value
         >::type>
         constexpr basic_tuple(Other&& other)
             : Base(detail::from_other{}, static_cast<Other&&>(other))

--- a/include/boost/hana/comparing.hpp
+++ b/include/boost/hana/comparing.hpp
@@ -12,6 +12,7 @@ Distributed under the Boost Software License, Version 1.0.
 
 #include <boost/hana/fwd/comparing.hpp>
 
+#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/config.hpp>
 #include <boost/hana/equal.hpp>
 
@@ -37,7 +38,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! @cond
     template <typename F>
     constexpr auto comparing_t::operator()(F&& f) const {
-        return detail::equal_by<typename std::decay<F>::type>{static_cast<F&&>(f)};
+        return detail::equal_by<typename detail::decay<F>::type>{static_cast<F&&>(f)};
     }
     //! @endcond
 BOOST_HANA_NAMESPACE_END

--- a/include/boost/hana/comparing.hpp
+++ b/include/boost/hana/comparing.hpp
@@ -12,8 +12,8 @@ Distributed under the Boost Software License, Version 1.0.
 
 #include <boost/hana/fwd/comparing.hpp>
 
-#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/config.hpp>
+#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/equal.hpp>
 
 #include <type_traits>

--- a/include/boost/hana/comparing.hpp
+++ b/include/boost/hana/comparing.hpp
@@ -16,8 +16,6 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/detail/decay.hpp>
 #include <boost/hana/equal.hpp>
 
-#include <type_traits>
-
 
 BOOST_HANA_NAMESPACE_BEGIN
     namespace detail {

--- a/include/boost/hana/detail/std_common_type.hpp
+++ b/include/boost/hana/detail/std_common_type.hpp
@@ -11,6 +11,7 @@ Distributed under the Boost Software License, Version 1.0.
 #define BOOST_HANA_DETAIL_STD_COMMON_TYPE_HPP
 
 #include <boost/hana/config.hpp>
+#include <boost/hana/detail/decay.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -27,7 +28,7 @@ BOOST_HANA_NAMESPACE_BEGIN namespace detail {
     struct std_common_type<T, U, decltype((void)(
         true ? std::declval<T>() : std::declval<U>()
     ))> {
-        using type = typename std::decay<
+        using type = typename detail::decay<
             decltype(true ? std::declval<T>() : std::declval<U>())
         >::type;
     };

--- a/include/boost/hana/detail/std_common_type.hpp
+++ b/include/boost/hana/detail/std_common_type.hpp
@@ -13,7 +13,6 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/config.hpp>
 #include <boost/hana/detail/decay.hpp>
 
-#include <type_traits>
 #include <utility>
 
 

--- a/include/boost/hana/experimental/view.hpp
+++ b/include/boost/hana/experimental/view.hpp
@@ -106,7 +106,7 @@ namespace experimental {
     };
 
     template <typename Sequence, typename F>
-    constexpr transformed_view_t<Sequence, typename std::decay<F>::type>
+    constexpr transformed_view_t<Sequence, typename hana::detail::decay<F>::type>
     transformed(Sequence& sequence, F&& f) {
         return {sequence, static_cast<F&&>(f)};
     }

--- a/include/boost/hana/ext/std/tuple.hpp
+++ b/include/boost/hana/ext/std/tuple.hpp
@@ -12,6 +12,7 @@ Distributed under the Boost Software License, Version 1.0.
 
 #include <boost/hana/bool.hpp>
 #include <boost/hana/config.hpp>
+#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/fwd/at.hpp>
 #include <boost/hana/fwd/core/make.hpp>
 #include <boost/hana/fwd/core/tag_of.hpp>
@@ -83,7 +84,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     struct lift_impl<ext::std::tuple_tag> {
         template <typename X>
         static constexpr auto apply(X&& x) {
-            return std::tuple<typename std::decay<X>::type>{
+            return std::tuple<typename detail::decay<X>::type>{
                                                 static_cast<X&&>(x)};
         }
     };

--- a/include/boost/hana/functional/curry.hpp
+++ b/include/boost/hana/functional/curry.hpp
@@ -11,6 +11,7 @@ Distributed under the Boost Software License, Version 1.0.
 #define BOOST_HANA_FUNCTIONAL_CURRY_HPP
 
 #include <boost/hana/config.hpp>
+#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/functional/apply.hpp>
 #include <boost/hana/functional/partial.hpp>
 
@@ -103,7 +104,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     template <std::size_t n>
     struct make_curry_t {
         template <typename F>
-        constexpr curry_t<n, typename std::decay<F>::type>
+        constexpr curry_t<n, typename detail::decay<F>::type>
         operator()(F&& f) const { return {static_cast<F&&>(f)}; }
     };
 

--- a/include/boost/hana/functional/infix.hpp
+++ b/include/boost/hana/functional/infix.hpp
@@ -11,6 +11,7 @@ Distributed under the Boost Software License, Version 1.0.
 #define BOOST_HANA_FUNCTIONAL_INFIX_HPP
 
 #include <boost/hana/config.hpp>
+#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/functional/partial.hpp>
 #include <boost/hana/functional/reverse_partial.hpp>
 
@@ -102,7 +103,7 @@ BOOST_HANA_NAMESPACE_BEGIN
         template <bool left, bool right>
         struct make_infix {
             template <typename F>
-            constexpr infix_t<left, right, typename std::decay<F>::type>
+            constexpr infix_t<left, right, typename detail::decay<F>::type>
             operator()(F&& f) const { return {static_cast<F&&>(f)}; }
         };
 

--- a/include/boost/hana/functional/lockstep.hpp
+++ b/include/boost/hana/functional/lockstep.hpp
@@ -15,7 +15,6 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/detail/decay.hpp>
 
 #include <cstddef>
-#include <type_traits>
 #include <utility>
 
 

--- a/include/boost/hana/functional/lockstep.hpp
+++ b/include/boost/hana/functional/lockstep.hpp
@@ -12,6 +12,7 @@ Distributed under the Boost Software License, Version 1.0.
 
 #include <boost/hana/basic_tuple.hpp>
 #include <boost/hana/config.hpp>
+#include <boost/hana/detail/decay.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -51,7 +52,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     struct make_pre_lockstep_t {
         struct secret { };
         template <typename F>
-        constexpr pre_lockstep_t<typename std::decay<F>::type> operator()(F&& f) const {
+        constexpr pre_lockstep_t<typename detail::decay<F>::type> operator()(F&& f) const {
             return {static_cast<F&&>(f)};
         }
     };
@@ -93,14 +94,14 @@ BOOST_HANA_NAMESPACE_BEGIN
 
         template <typename ...G>
         constexpr lockstep_t<std::make_index_sequence<sizeof...(G)>, F,
-                             typename std::decay<G>::type...>
+                             typename detail::decay<G>::type...>
         operator()(G&& ...g) const& {
             return {make_pre_lockstep_t::secret{}, this->f, static_cast<G&&>(g)...};
         }
 
         template <typename ...G>
         constexpr lockstep_t<std::make_index_sequence<sizeof...(G)>, F,
-                             typename std::decay<G>::type...>
+                             typename detail::decay<G>::type...>
         operator()(G&& ...g) && {
             return {make_pre_lockstep_t::secret{}, static_cast<F&&>(this->f),
                                                    static_cast<G&&>(g)...};

--- a/include/boost/hana/functional/overload_linearly.hpp
+++ b/include/boost/hana/functional/overload_linearly.hpp
@@ -86,8 +86,8 @@ BOOST_HANA_NAMESPACE_BEGIN
     struct make_overload_linearly_t {
         template <typename F, typename G>
         constexpr overload_linearly_t<
-            typename std::decay<F>::type,
-            typename std::decay<G>::type
+            typename detail::decay<F>::type,
+            typename detail::decay<G>::type
         > operator()(F&& f, G&& g) const {
             return {static_cast<F&&>(f), static_cast<G&&>(g)};
         }

--- a/include/boost/hana/functional/overload_linearly.hpp
+++ b/include/boost/hana/functional/overload_linearly.hpp
@@ -13,7 +13,6 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/config.hpp>
 #include <boost/hana/detail/decay.hpp>
 
-#include <type_traits>
 #include <utility>
 
 

--- a/include/boost/hana/fuse.hpp
+++ b/include/boost/hana/fuse.hpp
@@ -12,8 +12,8 @@ Distributed under the Boost Software License, Version 1.0.
 
 #include <boost/hana/fwd/fuse.hpp>
 
-#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/config.hpp>
+#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/unpack.hpp>
 
 #include <type_traits>

--- a/include/boost/hana/fuse.hpp
+++ b/include/boost/hana/fuse.hpp
@@ -12,6 +12,7 @@ Distributed under the Boost Software License, Version 1.0.
 
 #include <boost/hana/fwd/fuse.hpp>
 
+#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/config.hpp>
 #include <boost/hana/unpack.hpp>
 
@@ -40,7 +41,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! @cond
     template <typename F>
     constexpr auto fuse_t::operator()(F&& f) const {
-        return detail::fused<typename std::decay<F>::type>{static_cast<F&&>(f)};
+        return detail::fused<typename detail::decay<F>::type>{static_cast<F&&>(f)};
     }
     //! @endcond
 BOOST_HANA_NAMESPACE_END

--- a/include/boost/hana/fuse.hpp
+++ b/include/boost/hana/fuse.hpp
@@ -16,8 +16,6 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/detail/decay.hpp>
 #include <boost/hana/unpack.hpp>
 
-#include <type_traits>
-
 
 BOOST_HANA_NAMESPACE_BEGIN
     namespace detail {

--- a/include/boost/hana/monadic_fold_left.hpp
+++ b/include/boost/hana/monadic_fold_left.hpp
@@ -17,6 +17,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/concept/monad.hpp>
 #include <boost/hana/config.hpp>
 #include <boost/hana/core/dispatch.hpp>
+#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/fold_right.hpp>
 #include <boost/hana/functional/curry.hpp>
 #include <boost/hana/functional/partial.hpp>
@@ -111,7 +112,7 @@ BOOST_HANA_NAMESPACE_BEGIN
         template <typename M, typename Xs, typename F>
         static constexpr decltype(auto) apply(Xs&& xs, F&& f) {
             struct end { };
-            using G = detail::monadic_foldl1_helper<end, M, typename std::decay<F>::type>;
+            using G = detail::monadic_foldl1_helper<end, M, typename detail::decay<F>::type>;
             decltype(auto) result = hana::monadic_fold_left<M>(
                 static_cast<Xs&&>(xs),
                 end{},

--- a/include/boost/hana/monadic_fold_right.hpp
+++ b/include/boost/hana/monadic_fold_right.hpp
@@ -17,6 +17,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/concept/monad.hpp>
 #include <boost/hana/config.hpp>
 #include <boost/hana/core/dispatch.hpp>
+#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/fold_left.hpp>
 #include <boost/hana/functional/curry.hpp>
 #include <boost/hana/functional/partial.hpp>
@@ -110,7 +111,7 @@ BOOST_HANA_NAMESPACE_BEGIN
         template <typename M, typename Xs, typename F>
         static constexpr decltype(auto) apply(Xs&& xs, F&& f) {
             struct end { };
-            using G = detail::monadic_foldr1_helper<end, M, typename std::decay<F>::type>;
+            using G = detail::monadic_foldr1_helper<end, M, typename detail::decay<F>::type>;
             decltype(auto) result = hana::monadic_fold_right<M>(
                 static_cast<Xs&&>(xs),
                 end{},

--- a/include/boost/hana/optional.hpp
+++ b/include/boost/hana/optional.hpp
@@ -15,6 +15,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/bool.hpp>
 #include <boost/hana/config.hpp>
 #include <boost/hana/core/tag_of.hpp>
+#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/detail/operators/adl.hpp>
 #include <boost/hana/detail/operators/comparable.hpp>
 #include <boost/hana/detail/operators/monad.hpp>
@@ -115,7 +116,7 @@ BOOST_HANA_NAMESPACE_BEGIN
 
     template <typename T>
     constexpr auto make_just_t::operator()(T&& t) const {
-        return hana::optional<typename std::decay<T>::type>(static_cast<T&&>(t));
+        return hana::optional<typename detail::decay<T>::type>(static_cast<T&&>(t));
     }
     //! @endcond
 

--- a/include/boost/hana/ordering.hpp
+++ b/include/boost/hana/ordering.hpp
@@ -13,6 +13,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/fwd/ordering.hpp>
 
 #include <boost/hana/config.hpp>
+#include <boost/hana/detail/decay.hpp>
 #include <boost/hana/less.hpp>
 
 #include <type_traits>
@@ -37,7 +38,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! @cond
     template <typename F>
     constexpr auto ordering_t::operator()(F&& f) const {
-        return detail::less_by<typename std::decay<F>::type>{static_cast<F&&>(f)};
+        return detail::less_by<typename detail::decay<F>::type>{static_cast<F&&>(f)};
     }
     //! @endcond
 BOOST_HANA_NAMESPACE_END

--- a/include/boost/hana/ordering.hpp
+++ b/include/boost/hana/ordering.hpp
@@ -16,8 +16,6 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/detail/decay.hpp>
 #include <boost/hana/less.hpp>
 
-#include <type_traits>
-
 
 BOOST_HANA_NAMESPACE_BEGIN
     namespace detail {


### PR DESCRIPTION
* In implementation code, occurrences of `typename std::decay<...>::type` have been replaced with `typename hana::detail::decay<...>::type`.

* The rationale for this change, as mentioned in #282, is that `hana::detail::decay` performs better than `std::decay` in "libc++". I also think that using the same `decay` implementation throughout the library is more consistent.