### PR TITLE
Include at_key.hpp in map to fix issue with generic map access

### DIFF
--- a/include/boost/hana/map.hpp
+++ b/include/boost/hana/map.hpp
@@ -13,6 +13,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/fwd/map.hpp>
 
 #include <boost/hana/all_of.hpp>
+#include <boost/hana/at_key.hpp>
 #include <boost/hana/basic_tuple.hpp>
 #include <boost/hana/bool.hpp>
 #include <boost/hana/concept/comparable.hpp>


### PR DESCRIPTION
This is a small gripe, but I like to include the minimal set of headers in my project wherever possible. I ran into an issue with this in an example accessing a `hana::map` where the key is `type_c<T>` and T is a template parameter.

On develop with Clang 3.8, using the `examples` CMake target, the following code doesn't compile:

```
#include <boost/hana/map.hpp>
#include <iostream>

namespace hana = boost::hana;

constexpr auto max_value_map = hana::make_map(
  hana::make_pair(hana::type_c<unsigned char>,  255),
  hana::make_pair(hana::type_c<unsigned short>, 65535)
);

template<typename T>
void print_value() {
  std::cout << "maximum value is: " << max_value_map[hana::type_c<T>] << std::endl;
}

int main() {
  print_value<unsigned char>();
}
```

The error message originates at:

```
hana/include/boost/hana/detail/operators/searchable.hpp:34:20: error: 
      function 'operator()<const
      boost::hana::map<boost::hana::detail::hash_table<boost::hana::detail::bucket<unsigned char,
      0>, boost::hana::detail::bucket<unsigned short, 1>, boost::hana::detail::bucket<unsigned int,
      2>, boost::hana::detail::bucket<unsigned long, 3> >,
      boost::hana::basic_tuple<boost::hana::pair<boost::hana::type_impl<unsigned char>::_, int>,
      boost::hana::pair<boost::hana::type_impl<unsigned short>::_, int>,
      boost::hana::pair<boost::hana::type_impl<unsigned int>::_, unsigned int>,
      boost::hana::pair<boost::hana::type_impl<unsigned long>::_, unsigned long> > > &,
      boost::hana::type_impl<unsigned char>::_>' with deduced return type cannot be used before it
      is defined
            return hana::at_key(static_cast<Derived const&>(*this),
```

It did compile with `boost/hana.hpp`, but I thought we could do a bit better. Including `boost/hana/at_key.hpp` fixed my example. I thought it would be more intuitive if `boost/hana/map.hpp` pulled in that header.