### PR TITLE
[type] Add hana::typeid_ and deprecate hana::decltype_

### DIFF
--- a/example/filter.cpp
+++ b/example/filter.cpp
@@ -16,7 +16,7 @@ namespace hana = boost::hana;
 
 
 // First take the type of an object, and then tell whether it's integral
-constexpr auto is_integral = hana::compose(hana::trait<std::is_integral>, hana::decltype_);
+constexpr auto is_integral = hana::compose(hana::trait<std::is_integral>, hana::typeid_);
 
 static_assert(hana::filter(hana::make_tuple(1, 2.0, 3, 4.0), is_integral) == hana::make_tuple(1, 3), "");
 static_assert(hana::filter(hana::just(3), is_integral) == hana::just(3), "");

--- a/example/find_if.cpp
+++ b/example/find_if.cpp
@@ -17,8 +17,8 @@ namespace hana = boost::hana;
 
 
 // First get the type of the object, and then call the trait on it.
-constexpr auto is_integral = hana::compose(hana::trait<std::is_integral>, hana::decltype_);
-constexpr auto is_class = hana::compose(hana::trait<std::is_class>, hana::decltype_);
+constexpr auto is_integral = hana::compose(hana::trait<std::is_integral>, hana::typeid_);
+constexpr auto is_class = hana::compose(hana::trait<std::is_class>, hana::typeid_);
 
 static_assert(
     hana::find_if(hana::make_tuple(1.0, 2, '3'), is_integral) == hana::just(2)

--- a/example/group.cpp
+++ b/example/group.cpp
@@ -52,7 +52,7 @@ BOOST_HANA_CONSTANT_CHECK(
 
 // group.by is syntactic sugar
 static_assert(
-    hana::group.by(hana::comparing(hana::decltype_),
+    hana::group.by(hana::comparing(hana::typeid_),
                    hana::make_tuple(1, 2, 3, 'x', 'y', 4.4, 5.5))
         == hana::make_tuple(
             hana::make_tuple(1, 2, 3),

--- a/example/iterable/searchable.cpp
+++ b/example/iterable/searchable.cpp
@@ -17,8 +17,8 @@ namespace hana = boost::hana;
 
 
 // First get the type of the object, and then call the trait on it.
-constexpr auto is_integral = hana::compose(hana::trait<std::is_integral>, hana::decltype_);
-constexpr auto is_class = hana::compose(hana::trait<std::is_class>, hana::decltype_);
+constexpr auto is_integral = hana::compose(hana::trait<std::is_integral>, hana::typeid_);
+constexpr auto is_class = hana::compose(hana::trait<std::is_class>, hana::typeid_);
 
 static_assert(
     hana::find_if(hana::make_tuple(1.0, 2, '3'), is_integral)

--- a/example/misc/printf.cpp
+++ b/example/misc/printf.cpp
@@ -40,14 +40,14 @@ constexpr auto format(Tokens ...tokens_) {
     auto tokens = hana::make_tuple(tokens_...);
 
     // If you don't care about constexpr-ness of `format`, you can use
-    // this lambda instead of `compose(partial(...), decltype_)`:
+    // this lambda instead of `compose(partial(...), typeid_)`:
     //
     // [](auto token) {
-    //     return formats[decltype_(token)];
+    //     return formats[typeid_(token)];
     // }
     auto format_string_tokens = hana::adjust_if(tokens,
         hana::compose(hana::not_, hana::is_a<hana::string_tag>),
-        hana::compose(hana::partial(hana::at_key, formats), hana::decltype_)
+        hana::compose(hana::partial(hana::at_key, formats), hana::typeid_)
     );
 
     auto format_string = hana::fold_left(format_string_tokens, hana::string_c<>, concat_strings{});

--- a/example/monadic_compose.cpp
+++ b/example/monadic_compose.cpp
@@ -17,7 +17,7 @@ namespace hana = boost::hana;
 int main() {
     BOOST_HANA_CONSTEXPR_LAMBDA auto block = [](auto ...types) {
         return [=](auto x) {
-            return hana::if_(hana::contains(hana::make_tuple(types...), hana::decltype_(x)),
+            return hana::if_(hana::contains(hana::make_tuple(types...), hana::typeid_(x)),
                 hana::nothing,
                 hana::just(x)
             );

--- a/example/remove_if.cpp
+++ b/example/remove_if.cpp
@@ -16,7 +16,7 @@ namespace hana = boost::hana;
 
 
 // First get the type of the object, and then call the trait on it.
-constexpr auto is_integral = hana::compose(hana::trait<std::is_integral>, hana::decltype_);
+constexpr auto is_integral = hana::compose(hana::trait<std::is_integral>, hana::typeid_);
 
 static_assert(hana::remove_if(hana::make_tuple(1, 2.0, 3, 4.0), is_integral) == hana::make_tuple(2.0, 4.0), "");
 static_assert(hana::remove_if(hana::just(3.0), is_integral) == hana::just(3.0), "");

--- a/example/tutorial/rationale.container.cpp
+++ b/example/tutorial/rationale.container.cpp
@@ -22,7 +22,7 @@ int main() {
 auto tuple = hana::make_tuple(1, 'x', 3.4f);
 
 auto result = hana::find_if(tuple, [](auto const& x) {
-  return hana::traits::is_integral(hana::decltype_(x));
+  return hana::traits::is_integral(hana::typeid_(x));
 });
 //! [hana]
 (void)result;
@@ -30,7 +30,7 @@ auto result = hana::find_if(tuple, [](auto const& x) {
 #if 0
 //! [hana-explicit]
 some_type result = hana::find_if(tuple, [](auto const& x) {
-  return hana::traits::is_integral(hana::decltype_(x));
+  return hana::traits::is_integral(hana::typeid_(x));
 });
 //! [hana-explicit]
 #endif

--- a/example/tutorial/type.cpp
+++ b/example/tutorial/type.cpp
@@ -102,7 +102,7 @@ auto ts = hana::filter(types, [](auto t) {
 // values
 auto values = hana::make_tuple(1, 'c', nullptr, 3.5);
 auto vs = hana::filter(values, [](auto const& t) {
-  return is_integral(hana::decltype_(t));
+  return is_integral(hana::typeid_(t));
 });
 //! [single_library.Hana]
 

--- a/example/type/typeid.cpp
+++ b/example/type/typeid.cpp
@@ -1,0 +1,36 @@
+// Copyright Louis Dionne 2013-2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/equal.hpp>
+#include <boost/hana/remove_if.hpp>
+#include <boost/hana/tuple.hpp>
+#include <boost/hana/type.hpp>
+
+#include <string>
+namespace hana = boost::hana;
+
+
+struct Cat { std::string name; };
+struct Dog { std::string name; };
+struct Fish { std::string name; };
+
+bool operator==(Cat const& a, Cat const& b) { return a.name == b.name; }
+bool operator!=(Cat const& a, Cat const& b) { return a.name != b.name; }
+bool operator==(Dog const& a, Dog const& b) { return a.name == b.name; }
+bool operator!=(Dog const& a, Dog const& b) { return a.name != b.name; }
+bool operator==(Fish const& a, Fish const& b) { return a.name == b.name; }
+bool operator!=(Fish const& a, Fish const& b) { return a.name != b.name; }
+
+int main() {
+    hana::tuple<Cat, Fish, Dog, Fish> animals{
+        Cat{"Garfield"}, Fish{"Jaws"}, Dog{"Beethoven"}, Fish{"Nemo"}
+    };
+
+    auto mammals = hana::remove_if(animals, [](auto const& a) {
+        return hana::typeid_(a) == hana::type<Fish>{};
+    });
+
+    BOOST_HANA_RUNTIME_CHECK(mammals == hana::make_tuple(Cat{"Garfield"}, Dog{"Beethoven"}));
+}

--- a/example/unique.cpp
+++ b/example/unique.cpp
@@ -25,14 +25,14 @@ int main() {
     auto objects = hana::make_tuple(1, 2, "abc"s, 'd', "efg"s, "hij"s, 3.4f);
     BOOST_HANA_RUNTIME_CHECK(
         hana::unique(objects, [](auto const& t, auto const& u) {
-            return hana::decltype_(t) == hana::decltype_(u);
+            return hana::typeid_(t) == hana::typeid_(u);
         })
         == hana::make_tuple(1, "abc"s, 'd', "efg"s, 3.4f)
     );
 
     // unique.by is syntactic sugar
     BOOST_HANA_RUNTIME_CHECK(
-        hana::unique.by(hana::comparing(hana::decltype_), objects) ==
+        hana::unique.by(hana::comparing(hana::typeid_), objects) ==
             hana::make_tuple(1, "abc"s, 'd', "efg"s, 3.4f)
     );
 }

--- a/include/boost/hana/fwd/type.hpp
+++ b/include/boost/hana/fwd/type.hpp
@@ -121,6 +121,11 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! `decltype` keyword, lifted to Hana.
     //! @relates hana::type
     //!
+    //! @deprecated
+    //! The semantics of `decltype_` are can be confusing, and `hana::typeid_`
+    //! should be preferred instead. `decltype_` may be removed in the next
+    //! major version of the library.
+    //!
     //! `decltype_` is somewhat equivalent to `decltype` in that it returns
     //! the type of an object, except it returns it as a `hana::type` which
     //! is a first-class citizen of Hana instead of a raw C++ type.
@@ -181,6 +186,49 @@ BOOST_HANA_NAMESPACE_BEGIN
     };
 
     constexpr decltype_t decltype_{};
+#endif
+
+    //! Returns a `hana::type` representing the type of a given object.
+    //! @relates hana::type
+    //!
+    //! `hana::typeid_` is somewhat similar to `typeid` in that it returns
+    //! something that represents the type of an object. However, what
+    //! `typeid` returns represent the _runtime_ type of the object, while
+    //! `hana::typeid_` returns the _static_ type of the object. Specifically,
+    //! given an object `x`, `typeid_` satisfies
+    //! @code
+    //!   typeid_(x) == type_c<decltype(x) with ref and cv-qualifiers stripped>
+    //! @endcode
+    //!
+    //! As you can see, `typeid_` strips any reference and cv-qualifier from
+    //! the object's actual type. The reason for doing so is that it faithfully
+    //! models how the language's `typeid` behaves with respect to reference
+    //! and cv-qualifiers, and it also turns out to be the desirable behavior
+    //! most of the time. Also, when given a `hana::type`, `typeid_` is just
+    //! the identity function. Hence, for any C++ type `T`,
+    //! @code
+    //!   typeid_(type_c<T>) == type_c<T>
+    //! @endcode
+    //!
+    //! In conjunction with the way `metafunction` & al. are specified, this
+    //! behavior makes it easier to interact with both types and values at
+    //! the same time. However, it does make it impossible to create a `type`
+    //! containing another `type` using `typeid_`. This use case is assumed
+    //! to be rare and a hand-coded function can be used if this is needed.
+    //!
+    //!
+    //! Example
+    //! -------
+    //! @include example/type/typeid.cpp
+#ifdef BOOST_HANA_DOXYGEN_INVOKED
+    constexpr auto typeid_ = see documentation;
+#else
+    struct typeid_t {
+        template <typename T>
+        constexpr auto operator()(T&&) const;
+    };
+
+    constexpr typeid_t typeid_{};
 #endif
 
 #ifdef BOOST_HANA_DOXYGEN_INVOKED

--- a/include/boost/hana/type.hpp
+++ b/include/boost/hana/type.hpp
@@ -70,13 +70,35 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! @endcond
 
     //////////////////////////////////////////////////////////////////////////
+    // typeid_
+    //////////////////////////////////////////////////////////////////////////
+    namespace detail {
+        template <typename T, typename = type_tag>
+        struct typeid_t {
+            using type = typename std::remove_cv<
+                typename std::remove_reference<T>::type
+            >::type;
+        };
+
+        template <typename T>
+        struct typeid_t<T, typename hana::tag_of<T>::type> {
+            using type = typename std::remove_reference<T>::type::type;
+        };
+    }
+    //! @cond
+    template <typename T>
+    constexpr auto typeid_t::operator()(T&&) const
+    { return hana::type_c<typename detail::typeid_t<T>::type>; }
+    //! @endcond
+
+    //////////////////////////////////////////////////////////////////////////
     // make<type_tag>
     //////////////////////////////////////////////////////////////////////////
     template <>
     struct make_impl<type_tag> {
         template <typename T>
         static constexpr auto apply(T&& t)
-        { return hana::decltype_(static_cast<T&&>(t)); }
+        { return hana::typeid_(static_cast<T&&>(t)); }
     };
 
     //////////////////////////////////////////////////////////////////////////

--- a/test/type/adl.cpp
+++ b/test/type/adl.cpp
@@ -19,6 +19,6 @@ int main() {
     adl_pattern(hana::type_c<invalid<>>);
 
     // ADL instantiates the types recursively, make sure that works too
-    adl(hana::decltype_(hana::type_c<invalid<>>));
-    adl_pattern(hana::decltype_(hana::type_c<invalid<>>));
+    adl(hana::typeid_(hana::type_c<invalid<>>));
+    adl_pattern(hana::typeid_(hana::type_c<invalid<>>));
 }

--- a/test/type/typeid.cpp
+++ b/test/type/typeid.cpp
@@ -1,0 +1,182 @@
+// Copyright Louis Dionne 2013-2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/equal.hpp>
+#include <boost/hana/type.hpp>
+namespace hana = boost::hana;
+
+
+using Function = void();
+void function() { }
+
+int main() {
+    {
+        struct T { };
+        T t;
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(T{}),
+            hana::type_c<T>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(t),
+            hana::type_c<T>
+        ));
+    }
+
+    // [cv-qualified] reference types
+    {
+        struct T { };
+        T t;
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(static_cast<T&>(t)),
+            hana::type_c<T>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(static_cast<T const&>(t)),
+            hana::type_c<T>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(static_cast<T volatile&>(t)),
+            hana::type_c<T>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(static_cast<T const volatile&>(t)),
+            hana::type_c<T>
+        ));
+    }
+
+    // [cv-qualified] rvalue reference types
+    {
+        struct T { };
+        T t;
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(static_cast<T&&>(t)),
+            hana::type_c<T>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(static_cast<T const &&>(t)),
+            hana::type_c<T>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(static_cast<T volatile&&>(t)),
+            hana::type_c<T>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(static_cast<T const volatile&&>(t)),
+            hana::type_c<T>
+        ));
+    }
+
+    // typeid_(type_c<T>) is the identity function
+    {
+        struct T;
+        auto const type_const = hana::type_c<T>;
+        auto const& type_const_ref = hana::type_c<T>;
+        auto& type_ref = hana::type_c<T>;
+        auto&& type_ref_ref = static_cast<decltype(type_ref)&&>(type_ref);
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(hana::type_c<T>),
+            hana::type_c<T>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(type_const),
+            hana::type_c<T>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(type_const_ref),
+            hana::type_c<T>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(type_ref),
+            hana::type_c<T>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(type_ref_ref),
+            hana::type_c<T>
+        ));
+    }
+
+    // make sure we don't read from non-constexpr variables
+    {
+        struct T;
+        auto t = hana::type_c<T>;
+        auto x = 1;
+        constexpr auto r1 = hana::typeid_(t); (void)r1;
+        constexpr auto r2 = hana::typeid_(x); (void)r2;
+    }
+
+    // typeid_ with builtin arrays, function pointers and other weirdos
+    {
+        struct T { };
+        using A = T[3];
+        A a;
+        A& a_ref = a;
+        A const& a_const_ref = a;
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(a),
+            hana::type_c<A>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(a_ref),
+            hana::type_c<A>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(a_const_ref),
+            hana::type_c<A>
+        ));
+    }
+    {
+        using Fptr = int(*)();
+        Fptr f;
+        Fptr& f_ref = f;
+        Fptr const& f_const_ref = f;
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(f),
+            hana::type_c<Fptr>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(f_ref),
+            hana::type_c<Fptr>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(f_const_ref),
+            hana::type_c<Fptr>
+        ));
+    }
+    {
+        Function& function_ref = function;
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(function),
+            hana::type_c<Function>
+        ));
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::typeid_(function_ref),
+            hana::type_c<Function>
+        ));
+    }
+}


### PR DESCRIPTION
Candidate for satisfying #290. I'm still unsure whether using `typeof` would be better, though.