### PR TITLE
Unblock testing with MSVC

### DIFF
--- a/example/detail/wrong.cpp
+++ b/example/detail/wrong.cpp
@@ -12,7 +12,7 @@ struct base_template {
     // static_assert(false, "...");
 
     // So instead we write this:
-    static_assert(hana::detail::wrong<base_template<T, U>>{},
+    static_assert(hana::detail::wrong<base_template<T, U>>::value,
     "base_template does not have a valid default definition");
 };
 

--- a/include/boost/hana/config.hpp
+++ b/include/boost/hana/config.hpp
@@ -71,7 +71,11 @@ Distributed under the Boost Software License, Version 1.0.
 // Check the compiler for general C++14 capabilities
 //////////////////////////////////////////////////////////////////////////////
 #if (__cplusplus < 201400)
-#   warning "Your compiler doesn't provide C++14 or higher capabilities. Try adding the compiler flag '-std=c++14' or '-std=c++1y'."
+#   if defined(_MSC_VER)
+#       pragma message("Warning: Your compiler doesn't provide C++14 or higher capabilities. Try adding the compiler flag '-std=c++14' or '-std=c++1y'.")
+#   else
+#       warning "Your compiler doesn't provide C++14 or higher capabilities. Try adding the compiler flag '-std=c++14' or '-std=c++1y'."
+#   endif
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/include/boost/hana/detail/concepts.hpp
+++ b/include/boost/hana/detail/concepts.hpp
@@ -32,7 +32,7 @@ BOOST_HANA_NAMESPACE_BEGIN namespace detail {
 
     template <typename T, typename U>
     struct EqualityComparable<T, U, typename std::enable_if<
-        !std::is_same<T, U>{}, detail::void_t<
+        !std::is_same<T, U>::value, detail::void_t<
             decltype(static_cast<T&&>(*(T*)0) == static_cast<U&&>(*(U*)0) ? 0:0),
             decltype(static_cast<U&&>(*(U*)0) == static_cast<T&&>(*(T*)0) ? 0:0),
             decltype(static_cast<T&&>(*(T*)0) != static_cast<U&&>(*(U*)0) ? 0:0),

--- a/include/boost/hana/ext/std/integral_constant.hpp
+++ b/include/boost/hana/ext/std/integral_constant.hpp
@@ -85,7 +85,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     template <typename T, typename C>
     struct to_impl<ext::std::integral_constant_tag<T>, C, when<
         hana::IntegralConstant<C>::value
-    >> : embedding<is_embedded<typename C::value_type, T>{}> {
+    >> : embedding<is_embedded<typename C::value_type, T>::value> {
         template <typename N>
         static constexpr auto apply(N const&) {
             return std::integral_constant<T, N::value>{};

--- a/test/core/tag_of.cpp
+++ b/test/core/tag_of.cpp
@@ -11,20 +11,20 @@ namespace hana = boost::hana;
 
 template <typename T, typename ExpectedDatatype>
 struct test {
-    static_assert(std::is_same<hana::tag_of_t<T>, ExpectedDatatype>{}, "");
-    static_assert(std::is_same<hana::tag_of_t<T const>, ExpectedDatatype>{}, "");
-    static_assert(std::is_same<hana::tag_of_t<T volatile>, ExpectedDatatype>{}, "");
-    static_assert(std::is_same<hana::tag_of_t<T const volatile>, ExpectedDatatype>{}, "");
+    static_assert(std::is_same<hana::tag_of_t<T>, ExpectedDatatype>::value, "");
+    static_assert(std::is_same<hana::tag_of_t<T const>, ExpectedDatatype>::value, "");
+    static_assert(std::is_same<hana::tag_of_t<T volatile>, ExpectedDatatype>::value, "");
+    static_assert(std::is_same<hana::tag_of_t<T const volatile>, ExpectedDatatype>::value, "");
 
-    static_assert(std::is_same<hana::tag_of_t<T&>, ExpectedDatatype>{}, "");
-    static_assert(std::is_same<hana::tag_of_t<T const&>, ExpectedDatatype>{}, "");
-    static_assert(std::is_same<hana::tag_of_t<T volatile&>, ExpectedDatatype>{}, "");
-    static_assert(std::is_same<hana::tag_of_t<T const volatile&>, ExpectedDatatype>{}, "");
+    static_assert(std::is_same<hana::tag_of_t<T&>, ExpectedDatatype>::value, "");
+    static_assert(std::is_same<hana::tag_of_t<T const&>, ExpectedDatatype>::value, "");
+    static_assert(std::is_same<hana::tag_of_t<T volatile&>, ExpectedDatatype>::value, "");
+    static_assert(std::is_same<hana::tag_of_t<T const volatile&>, ExpectedDatatype>::value, "");
 
-    static_assert(std::is_same<hana::tag_of_t<T&&>, ExpectedDatatype>{}, "");
-    static_assert(std::is_same<hana::tag_of_t<T const&&>, ExpectedDatatype>{}, "");
-    static_assert(std::is_same<hana::tag_of_t<T volatile&&>, ExpectedDatatype>{}, "");
-    static_assert(std::is_same<hana::tag_of_t<T const volatile&&>, ExpectedDatatype>{}, "");
+    static_assert(std::is_same<hana::tag_of_t<T&&>, ExpectedDatatype>::value, "");
+    static_assert(std::is_same<hana::tag_of_t<T const&&>, ExpectedDatatype>::value, "");
+    static_assert(std::is_same<hana::tag_of_t<T volatile&&>, ExpectedDatatype>::value, "");
+    static_assert(std::is_same<hana::tag_of_t<T const volatile&&>, ExpectedDatatype>::value, "");
 };
 
 struct NestedDatatype;

--- a/test/detail/any_of.cpp
+++ b/test/detail/any_of.cpp
@@ -35,7 +35,7 @@ static_assert(hana::detail::any_of<is_even, hana::int_<1>, hana::int_<8>, hana::
 // Make sure we short-circuit properly
 template <typename ...Dummy>
 struct fail {
-    static_assert(hana::detail::wrong<Dummy...>{},
+    static_assert(hana::detail::wrong<Dummy...>::value,
         "this must never be instantiated");
 };
 static_assert(hana::detail::any_of<is_even, hana::int_<1>, hana::int_<2>, fail<>>::value, "");


### PR DESCRIPTION
MSVC doesn't like the #warning directive and issues a fatal error.
It also sets _MSVC_LANG to 201402 for C++14 instead of __cplusplus, but that's the minimum value anyway.
It also doesn't like using {} instead of ::value for some type traits sometimes and issues an error about a missing default constructor. ::value is used most of the time anyway.