### PR TITLE
Fix Github Issue #304

### DIFF
--- a/include/boost/hana/ext/std/array.hpp
+++ b/include/boost/hana/ext/std/array.hpp
@@ -93,7 +93,7 @@ BOOST_HANA_NAMESPACE_BEGIN
         template <typename Xs, typename N>
         static constexpr decltype(auto) apply(Xs&& xs, N const&) {
             constexpr std::size_t n = N::value;
-            return static_cast<Xs&&>(xs)[n];
+            return std::get<n>(static_cast<Xs&&>(xs));
         }
     };
 

--- a/test/ext/std/array/at.cpp
+++ b/test/ext/std/array/at.cpp
@@ -1,0 +1,43 @@
+// Copyright Louis Dionne 2013-2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/ext/std/array.hpp>
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/at.hpp>
+
+#include <laws/base.hpp> // for move_only
+
+#include <array>
+namespace hana = boost::hana;
+
+
+int main() {
+    // Check non-const lvalue reference
+    {
+        std::array<int, 2> arr = {{999, 888}};
+        int& i = hana::at_c<0>(arr);
+        BOOST_HANA_RUNTIME_CHECK(i == 999);
+        arr[0] = 333;
+        BOOST_HANA_RUNTIME_CHECK(i == 333);
+        i = 444;
+        BOOST_HANA_RUNTIME_CHECK(arr[0] == 444);
+    }
+
+    // Check const lvalue reference
+    {
+        std::array<int, 2> arr = {{999, 888}};
+        int const& i = hana::at_c<0>(static_cast<std::array<int, 2> const&>(arr));
+        BOOST_HANA_RUNTIME_CHECK(i == 999);
+        arr[0] = 333;
+        BOOST_HANA_RUNTIME_CHECK(i == 333);
+    }
+
+    // Check move-only types
+    {
+        std::array<hana::test::move_only, 2> arr{};
+        hana::test::move_only m = hana::at_c<0>(std::move(arr));
+        (void)m;
+    }
+}

--- a/test/ext/std/array/issue_304.cpp
+++ b/test/ext/std/array/issue_304.cpp
@@ -1,0 +1,21 @@
+// Copyright Jason Rice 2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+// modified from https://github.com/boostorg/hana/issues/304
+
+#include <boost/hana/ext/std/array.hpp>
+#include <boost/hana/tuple.hpp>
+
+namespace hana = boost::hana;
+
+struct Foo
+{
+    Foo() = default;
+    Foo(Foo const&) = delete;
+    Foo(Foo &&) = default;
+};
+
+using bar = decltype(hana::to_tuple(std::array<Foo, 2>()));
+
+int main()
+{ }


### PR DESCRIPTION
  - Apparently std::array operator[] returns an lvalue reference when unpacking
    a temporary std::array. Using std::get<n> returns the
    proper reference type in the case of rvalues.