### PR TITLE
Make sure core metafunctions return IntegralConstants

### DIFF
--- a/include/boost/hana/core/common.hpp
+++ b/include/boost/hana/core/common.hpp
@@ -16,10 +16,9 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/config.hpp>
 #include <boost/hana/core/when.hpp>
 #include <boost/hana/detail/canonical_constant.hpp>
+#include <boost/hana/detail/integral_constant.hpp>
 #include <boost/hana/detail/std_common_type.hpp>
 #include <boost/hana/detail/void_t.hpp>
-
-#include <type_traits>
 
 
 BOOST_HANA_NAMESPACE_BEGIN
@@ -45,11 +44,11 @@ BOOST_HANA_NAMESPACE_BEGIN
     // has_common
     //////////////////////////////////////////////////////////////////////////
     template <typename T, typename U, typename>
-    struct has_common : std::false_type { };
+    struct has_common : hana::integral_constant<bool, false> { };
 
     template <typename T, typename U>
     struct has_common<T, U, detail::void_t<typename common<T, U>::type>>
-        : std::true_type
+        : hana::integral_constant<bool, true>
     { };
 
     //////////////////////////////////////////////////////////////////////////

--- a/include/boost/hana/core/default.hpp
+++ b/include/boost/hana/core/default.hpp
@@ -13,19 +13,18 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/fwd/core/default.hpp>
 
 #include <boost/hana/config.hpp>
-
-#include <type_traits>
+#include <boost/hana/detail/integral_constant.hpp>
 
 
 BOOST_HANA_NAMESPACE_BEGIN
     template <typename Method, typename>
-    struct is_default : std::false_type { };
+    struct is_default : hana::integral_constant<bool, false> { };
 
     template <typename Method>
     struct is_default<Method, decltype((void)
         static_cast<default_>(*(Method*)0)
     )>
-        : std::true_type
+        : hana::integral_constant<bool, true>
     { };
 BOOST_HANA_NAMESPACE_END
 

--- a/include/boost/hana/core/to.hpp
+++ b/include/boost/hana/core/to.hpp
@@ -19,6 +19,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/core/common.hpp>
 #include <boost/hana/core/dispatch.hpp>
 #include <boost/hana/core/make.hpp>
+#include <boost/hana/detail/integral_constant.hpp>
 #include <boost/hana/detail/wrong.hpp>
 #include <boost/hana/unpack.hpp>
 #include <boost/hana/value.hpp>
@@ -146,23 +147,23 @@ BOOST_HANA_NAMESPACE_BEGIN
     // is_convertible
     //////////////////////////////////////////////////////////////////////////
     template <typename From, typename To, typename>
-    struct is_convertible : std::true_type { };
+    struct is_convertible : hana::integral_constant<bool, true> { };
 
     template <typename From, typename To>
     struct is_convertible<From, To, decltype((void)
         static_cast<convert_detail::no_conversion>(*(to_impl<To, From>*)0)
-    )> : std::false_type { };
+    )> : hana::integral_constant<bool, false> { };
 
     //////////////////////////////////////////////////////////////////////////
     // is_embedded
     //////////////////////////////////////////////////////////////////////////
     template <typename From, typename To, typename>
-    struct is_embedded : std::false_type { };
+    struct is_embedded : hana::integral_constant<bool, false> { };
 
     template <typename From, typename To>
     struct is_embedded<From, To, decltype((void)
         static_cast<embedding<true>>(*(to_impl<To, From>*)0)
-    )> : std::true_type { };
+    )> : hana::integral_constant<bool, true> { };
 
     //////////////////////////////////////////////////////////////////////////
     // Conversion for Constants

--- a/test/core/common.cpp
+++ b/test/core/common.cpp
@@ -2,7 +2,9 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#include <boost/hana/concept/integral_constant.hpp>
 #include <boost/hana/core/common.hpp>
+#include <boost/hana/not.hpp>
 
 #include <type_traits>
 namespace hana = boost::hana;
@@ -28,5 +30,7 @@ static_assert(!hana::has_common<void, T>{}, "");
 static_assert(!hana::has_common<T, void>{}, "");
 static_assert(!hana::has_common<invalid, T>{}, "");
 static_assert(!hana::has_common<T, invalid>{}, "");
+
+static_assert(hana::IntegralConstant<hana::has_common<T, T>>{}, "");
 
 int main() { }

--- a/test/core/default.cpp
+++ b/test/core/default.cpp
@@ -3,6 +3,8 @@
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 #include <boost/hana/core/default.hpp>
+
+#include <boost/hana/concept/integral_constant.hpp>
 namespace hana = boost::hana;
 
 
@@ -14,5 +16,7 @@ struct method_impl<int> { };
 
 static_assert(hana::is_default<method_impl<void>>{}, "");
 static_assert(!hana::is_default<method_impl<int>>{}, "");
+
+static_assert(hana::IntegralConstant<hana::is_default<method_impl<void>>>{}, "");
 
 int main() { }

--- a/test/core/is_embedded.cpp
+++ b/test/core/is_embedded.cpp
@@ -2,12 +2,15 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#include <boost/hana/concept/integral_constant.hpp>
 #include <boost/hana/core/to.hpp>
 #include <boost/hana/equal.hpp>
 
 #include <climits>
 namespace hana = boost::hana;
 
+
+static_assert(hana::IntegralConstant<hana::is_embedded<float, double>>{}, "");
 
 // This test makes sure that fundamental types are properly embedded in
 // each other, when sensible.

--- a/test/core/to.cpp
+++ b/test/core/to.cpp
@@ -5,6 +5,7 @@
 #include <boost/hana/core/to.hpp>
 
 #include <boost/hana/assert.hpp>
+#include <boost/hana/concept/integral_constant.hpp>
 #include <boost/hana/core/tag_of.hpp>
 
 #include <string>
@@ -103,4 +104,6 @@ int main() {
 
     static_assert(hana::is_convertible<int, void>{}, "");
     static_assert(!hana::is_embedded<int, void>{}, "");
+
+    static_assert(hana::IntegralConstant<hana::is_convertible<int, void>>{}, "");
 }


### PR DESCRIPTION
This PR is an attempt to address #54, and I will be closing #54 in favor of this PR.

This does not work right now, because we would need to include the full definition of `hana::integral_constant` in core metafunctions, and that introduces circular dependencies.