### PR TITLE
[view] cartesian_product

### DIFF
--- a/include/boost/hana/cartesian_product.hpp
+++ b/include/boost/hana/cartesian_product.hpp
@@ -49,7 +49,7 @@ BOOST_HANA_NAMESPACE_BEGIN
         template <std::size_t ...Lengths>
         struct cartesian_product_indices {
             static constexpr std::size_t total_length() {
-                std::size_t lengths[] = {Lengths...};
+                std::size_t lengths[sizeof...(Lengths)] = {Lengths...};
                 std::size_t r = 1;
                 for (std::size_t len: lengths)
                     r *= len;
@@ -59,9 +59,12 @@ BOOST_HANA_NAMESPACE_BEGIN
             static constexpr std::size_t length = total_length();
 
             static constexpr auto indices_of(std::size_t i) {
-                constexpr std::size_t lengths[] = {Lengths...};
                 constexpr std::size_t n = sizeof...(Lengths);
+                constexpr std::size_t lengths[n] = {Lengths...};
                 detail::array<std::size_t, n> result{};
+                if (length == 0) {
+                    return result;
+                }
                 for (std::size_t j = n; j--;) {
                     result[j] = i % lengths[j];
                     i /= lengths[j];
@@ -69,19 +72,70 @@ BOOST_HANA_NAMESPACE_BEGIN
                 return result;
             }
 
-            template <typename S, std::size_t n, std::size_t ...k, typename ...Xs>
+            template <std::size_t n, typename F, std::size_t ...k, typename ...Xs>
             static constexpr auto
-            product_element(std::index_sequence<k...>, Xs&& ...xs) {
+            product_element(std::index_sequence<k...>, F&& f, Xs&& ...xs) {
                 constexpr auto indices = indices_of(n);
-                return hana::make<S>(hana::at_c<indices[k]>(xs)...);
+                return static_cast<F&&>(f)(hana::at_c<indices[k]>(xs)...);
             }
 
-            template <typename S, std::size_t ...n, typename ...Xs>
+            template <std::size_t ...n, typename F, typename ...Xs>
             static constexpr auto
-            create_product(std::index_sequence<n...>, Xs&& ...xs) {
-                return hana::make<S>(product_element<S, n>(
-                    std::make_index_sequence<sizeof...(Xs)>{}, xs...
+            create_product(std::index_sequence<n...>, F&& f, Xs&& ...xs) {
+                return F{}(product_element<n>(
+                    std::make_index_sequence<sizeof...(Xs)>{},
+                    static_cast<F&&>(f), xs...
                 )...);
+            }
+        };
+
+        template <>
+        struct cartesian_product_indices<> {
+            static constexpr std::size_t total_length()
+            { return 0; }
+
+            static constexpr std::size_t length = 0;
+        };
+
+        struct make_cartesian_product_indices_helper_t {
+            template <typename ...Xs>
+            constexpr auto operator()(Xs&& ...xs) const
+                -> detail::cartesian_product_indices<
+                       decltype(hana::length(xs))::value...
+                   >
+            { return {}; }
+        };
+
+        struct make_cartesian_product_indices_t {
+            template <typename Xs>
+            constexpr auto operator()(Xs&& xs) const {
+                return hana::unpack(
+                    static_cast<Xs&&>(xs),
+                    make_cartesian_product_indices_helper_t{});
+            }
+        };
+
+        constexpr make_cartesian_product_indices_t make_cartesian_product_indices{};
+
+        template <typename F, std::size_t n>
+        struct make_cartesian_product_element_t {
+            F const& f;
+
+            constexpr auto operator()() const {
+                return f();
+            }
+
+            template <typename X1, typename ...Xs>
+            constexpr auto operator()(X1&& x1, Xs&& ...xs) const {
+                constexpr auto indices = detail::cartesian_product_indices<
+                    decltype(hana::length(x1))::value,
+                    decltype(hana::length(xs))::value...
+                >{};
+                return indices.template product_element<n>(
+                    std::make_index_sequence<sizeof...(Xs) + 1>{}, f,
+                    static_cast<X1&&>(x1),
+                    static_cast<Xs&&>(xs)...
+                );
             }
         };
     }
@@ -99,8 +153,9 @@ BOOST_HANA_NAMESPACE_BEGIN
             using indices = detail::cartesian_product_indices<
                 decltype(hana::length(xs))::value...
             >;
-            return indices::template create_product<S>(
+            return indices::template create_product(
                         std::make_index_sequence<indices::length>{},
+                        hana::make<S>,
                         static_cast<Xs&&>(xs)...);
         }
 

--- a/test/view/cartesian_product/at.cpp
+++ b/test/view/cartesian_product/at.cpp
@@ -1,0 +1,88 @@
+// Copyright Louis Dionne 2013-2016
+// Copyright Jason Rice 2017
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/at.hpp>
+#include <boost/hana/equal.hpp>
+#include <boost/hana/integral_constant.hpp>
+#include <boost/hana/view.hpp>
+
+#include <laws/base.hpp>
+#include <support/seq.hpp>
+namespace hana = boost::hana;
+using hana::test::ct_eq;
+
+
+int main() {
+    auto container = ::seq;
+
+    {
+        const auto storage = container(
+            container(ct_eq<0>{})
+        );
+
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::at(view, hana::size_c<0>),
+            container(ct_eq<0>{})
+        ));
+    }
+
+    {
+        const auto storage = container(
+            container(ct_eq<0>{}),
+            container(ct_eq<0>{})
+        );
+
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::at(view, hana::size_c<0>),
+            container(ct_eq<0>{}, ct_eq<0>{})
+        ));
+    }
+
+    {
+        const auto storage = container(
+            container(ct_eq<0>{}, ct_eq<1>{}, ct_eq<2>{}),
+            container(ct_eq<3>{}, ct_eq<4>{})
+        );
+
+        auto view = hana::detail::cartesian_product_view(storage);
+
+        auto expected = container(
+            container(ct_eq<0>{}, ct_eq<3>{}),
+            container(ct_eq<0>{}, ct_eq<4>{}),
+            container(ct_eq<1>{}, ct_eq<3>{}),
+            container(ct_eq<1>{}, ct_eq<4>{}),
+            container(ct_eq<2>{}, ct_eq<3>{}),
+            container(ct_eq<2>{}, ct_eq<4>{})
+        );
+
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::at(view,     hana::size_c<0>),
+            hana::at(expected, hana::size_c<0>)
+        ));
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::at(view,     hana::size_c<1>),
+            hana::at(expected, hana::size_c<1>)
+        ));
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::at(view,     hana::size_c<2>),
+            hana::at(expected, hana::size_c<2>)
+        ));
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::at(view,     hana::size_c<3>),
+            hana::at(expected, hana::size_c<3>)
+        ));
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::at(view,     hana::size_c<4>),
+            hana::at(expected, hana::size_c<4>)
+        ));
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::at(view,     hana::size_c<5>),
+            hana::at(expected, hana::size_c<5>)
+        ));
+    }
+}

--- a/test/view/cartesian_product/is_empty.cpp
+++ b/test/view/cartesian_product/is_empty.cpp
@@ -1,0 +1,71 @@
+// Copyright Louis Dionne 2013-2016
+// Copyright Jason Rice 2017
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/is_empty.hpp>
+#include <boost/hana/not.hpp>
+#include <boost/hana/view.hpp>
+
+#include <laws/base.hpp>
+#include <support/seq.hpp>
+namespace hana = boost::hana;
+using hana::test::ct_eq;
+
+
+int main() {
+    auto container = ::seq;
+
+    {
+        auto storage = container(container());
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::is_empty(view));
+    }
+
+    {
+        auto storage = container(container(ct_eq<0>{}), container());
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::is_empty(view));
+    }
+
+    {
+        auto storage = container(
+            container(ct_eq<0>{}),
+            container(ct_eq<1>{}),
+            container(ct_eq<2>{}, ct_eq<3>{}),
+            container(),
+            container(ct_eq<4>{})
+        );
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::is_empty(view));
+    }
+
+    {
+        auto storage = container(container(ct_eq<0>{}));
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::is_empty(view)));
+    }
+
+    {
+        auto storage = container(
+            container(ct_eq<0>{}),
+            container(ct_eq<1>{}),
+            container(ct_eq<2>{}, ct_eq<3>{}),
+            container(ct_eq<4>{})
+        );
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::is_empty(view)));
+    }
+
+    {
+        auto storage = container(
+            container(ct_eq<0>{}),
+            container(ct_eq<1>{}),
+            container(ct_eq<2>{}, ct_eq<3>{}),
+            container(ct_eq<4>{}, ct_eq<5>{}, ct_eq<6>{})
+        );
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::not_(hana::is_empty(view)));
+    }
+}

--- a/test/view/cartesian_product/length.cpp
+++ b/test/view/cartesian_product/length.cpp
@@ -1,0 +1,86 @@
+// Copyright Louis Dionne 2013-2016
+// Copyright Jason Rice 2017
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/length.hpp>
+#include <boost/hana/not.hpp>
+#include <boost/hana/view.hpp>
+
+#include <laws/base.hpp>
+#include <support/seq.hpp>
+namespace hana = boost::hana;
+using hana::test::ct_eq;
+
+
+int main() {
+    auto container = ::seq;
+
+    {
+        auto storage = container(container());
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::length(view),
+            hana::size_c<0>
+        ));
+    }
+
+    {
+        auto storage = container(container(ct_eq<0>{}), container());
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::is_empty(view));
+    }
+
+    {
+        auto storage = container(
+            container(ct_eq<0>{}),
+            container(ct_eq<1>{}),
+            container(ct_eq<2>{}, ct_eq<3>{}),
+            container(),
+            container(ct_eq<4>{})
+        );
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::length(view),
+            hana::size_c<0>
+        ));
+    }
+
+    {
+        auto storage = container(container(ct_eq<0>{}));
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::length(view),
+            hana::size_c<1>
+        ));
+    }
+
+    {
+        auto storage = container(
+            container(ct_eq<0>{}),
+            container(ct_eq<1>{}),
+            container(ct_eq<2>{}, ct_eq<3>{}),
+            container(ct_eq<4>{})
+        );
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::length(view),
+            hana::size_c<2>
+        ));
+    }
+
+    {
+        auto storage = container(
+            container(ct_eq<0>{}),
+            container(ct_eq<1>{}),
+            container(ct_eq<2>{}, ct_eq<3>{}),
+            container(ct_eq<4>{}, ct_eq<5>{}, ct_eq<6>{})
+        );
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::length(view),
+            hana::size_c<6>
+        ));
+    }
+}

--- a/test/view/cartesian_product/modifications.cpp
+++ b/test/view/cartesian_product/modifications.cpp
@@ -1,0 +1,39 @@
+// Copyright Louis Dionne 2013-2016
+// Copyright Jason Rice 2017
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/at.hpp>
+#include <boost/hana/view.hpp>
+
+#include <support/seq.hpp>
+namespace hana = boost::hana;
+
+
+int main() {
+    auto container = ::seq;
+
+    auto storage = container(container(0),
+                             container(1),
+                             container(2, 3),
+                             container(4, 5, 6));
+
+    auto view = hana::detail::cartesian_product_view(storage);
+
+    hana::at_c<0>(hana::at_c<0>(view)) = 90;
+    hana::at_c<1>(hana::at_c<0>(view)) = 91;
+    hana::at_c<2>(hana::at_c<0>(view)) = 92;
+    hana::at_c<3>(hana::at_c<0>(view)) = 94;
+    hana::at_c<3>(hana::at_c<1>(view)) = 95;
+    hana::at_c<2>(hana::at_c<5>(view)) = 93;
+    hana::at_c<3>(hana::at_c<5>(view)) = 96;
+
+    BOOST_HANA_RUNTIME_CHECK(hana::equal(
+        storage,
+        container(container(90),
+                  container(91),
+                  container(92, 93),
+                  container(94, 95, 96))
+    ));
+}

--- a/test/view/cartesian_product/unpack.cpp
+++ b/test/view/cartesian_product/unpack.cpp
@@ -1,0 +1,111 @@
+// Copyright Louis Dionne 2013-2016
+// Copyright Jason Rice 2017
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <boost/hana/assert.hpp>
+#include <boost/hana/unpack.hpp>
+#include <boost/hana/view.hpp>
+
+#include <laws/base.hpp>
+#include <support/seq.hpp>
+namespace hana = boost::hana;
+using hana::test::ct_eq;
+
+
+int main() {
+    auto container = ::seq;
+    auto make_container = [](auto ...x) {
+        return ::seq(x...);
+    };
+
+    {
+        auto storage = container();
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::is_empty(view));
+        BOOST_HANA_CONSTANT_CHECK(hana::is_empty(hana::unpack(view, make_container)));
+    }
+
+    {
+        auto storage = container(container());
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::is_empty(view));
+        BOOST_HANA_CONSTANT_CHECK(hana::is_empty(hana::unpack(view, make_container)));
+    }
+
+    {
+        auto storage = container(container(), container(), container());
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::is_empty(view));
+        BOOST_HANA_CONSTANT_CHECK(hana::is_empty(hana::unpack(view, make_container)));
+    }
+
+    {
+        auto storage = container(container(ct_eq<0>{}), container());
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::is_empty(view));
+        BOOST_HANA_CONSTANT_CHECK(hana::is_empty(hana::unpack(view, make_container)));
+    }
+
+    {
+        auto storage = container(
+            container(ct_eq<0>{}),
+            container(ct_eq<1>{}),
+            container(ct_eq<2>{}, ct_eq<3>{}),
+            container(),
+            container(ct_eq<4>{})
+        );
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(view, make_container),
+            container()
+        ));
+    }
+
+    {
+        auto storage = container(container(ct_eq<0>{}));
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(view, make_container),
+            container(container(ct_eq<0>{}))
+        ));
+    }
+
+    {
+        auto storage = container(
+            container(ct_eq<0>{}),
+            container(ct_eq<1>{}),
+            container(ct_eq<2>{}, ct_eq<3>{}),
+            container(ct_eq<4>{})
+        );
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(view, make_container),
+            container(
+              container(ct_eq<0>{}, ct_eq<1>{}, ct_eq<2>{}, ct_eq<4>{}),
+              container(ct_eq<0>{}, ct_eq<1>{}, ct_eq<3>{}, ct_eq<4>{})
+            )
+        ));
+    }
+
+    {
+        auto storage = container(
+            container(ct_eq<0>{}),
+            container(ct_eq<1>{}),
+            container(ct_eq<2>{}, ct_eq<3>{}),
+            container(ct_eq<4>{}, ct_eq<5>{}, ct_eq<6>{})
+        );
+        auto view = hana::detail::cartesian_product_view(storage);
+        BOOST_HANA_CONSTANT_CHECK(hana::equal(
+            hana::unpack(view, make_container),
+            container(
+              container(ct_eq<0>{}, ct_eq<1>{}, ct_eq<2>{}, ct_eq<4>{}),
+              container(ct_eq<0>{}, ct_eq<1>{}, ct_eq<2>{}, ct_eq<5>{}),
+              container(ct_eq<0>{}, ct_eq<1>{}, ct_eq<2>{}, ct_eq<6>{}),
+              container(ct_eq<0>{}, ct_eq<1>{}, ct_eq<3>{}, ct_eq<4>{}),
+              container(ct_eq<0>{}, ct_eq<1>{}, ct_eq<3>{}, ct_eq<5>{}),
+              container(ct_eq<0>{}, ct_eq<1>{}, ct_eq<3>{}, ct_eq<6>{})
+            )
+        ));
+    }
+}


### PR DESCRIPTION
  - Adds cartesian_product_view_t and cartesian_product_element_view_t
    with specializations for the following:
      - at_impl
      - is_empty_impl
      - length_impl
      - unpack_impl

Note: The name `hana::detail::cartesian_product` is being used because I think we can change namespace `detail` here to `view` to expose these functions. This is important since we can't implement Sequence functions as the view "type" is not technically a Sequence.

We could also then change names like `joined` and `flattened` to simply `view::join` and `view::flatten` so the naming is consistent.