### PR TITLE
Make some containers final and add notes about assumptions about representation

### DIFF
--- a/doc/tutorial.hpp
+++ b/doc/tutorial.hpp
@@ -2024,7 +2024,10 @@ a container unspecified; they are explained in the
 [rationales](@ref tutorial-rationales-container_representation).
 When the representation of a container is implementation-defined, one must
 be careful not to make any assumptions about it, unless those assumption
-are explicitly allowed in the documentation of the container.
+are explicitly allowed in the documentation of the container. For example,
+assuming that one can safely inherit from a container or that the elements
+in the container are stored in the same order as specified in its template
+argument list is generally not safe.
 
 
 @subsubsection tutorial-containers-types-overloading Overloading on container types

--- a/include/boost/hana/fwd/basic_tuple.hpp
+++ b/include/boost/hana/fwd/basic_tuple.hpp
@@ -22,6 +22,11 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! `std::tuple`, `basic_tuple` provides the strict minimum required to
     //! implement a closure with maximum compile-time efficiency.
     //!
+    //! @note
+    //! When you use a container, remember not to make assumptions about its
+    //! representation, unless the documentation gives you those guarantees.
+    //! More details [in the tutorial](@ref tutorial-containers-types).
+    //!
     //!
     //! Modeled concepts
     //! ----------------

--- a/include/boost/hana/fwd/map.hpp
+++ b/include/boost/hana/fwd/map.hpp
@@ -36,21 +36,23 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! keys must be `Hashable`, and any two keys with equal hashes must be
     //! `Comparable` with each other at compile-time.
     //!
-    //! Note that the actual representation of a `hana::map` is an implementation
+    //! @note
+    //! The actual representation of a `hana::map` is an implementation
     //! detail. As such, one should not assume anything more than what is
     //! explicitly documented as being part of the interface of a map,
     //! such as:
     //! - the presence of additional constructors
     //! - the presence of additional assignment operators
     //! - the fact that `hana::map<Pairs...>` is, or is not, a dependent type
-    //!
+    //! .
     //! In particular, the last point is very important; `hana::map<Pairs...>`
     //! is basically equivalent to
     //! @code
     //!     decltype(hana::make_pair(std::declval<Pairs>()...))
     //! @endcode
     //! which is not something that can be pattern-matched on during template
-    //! argument deduction, for example.
+    //! argument deduction, for example. More details [in the tutorial]
+    //! (@ref tutorial-containers-types).
     //!
     //!
     //! Modeled concepts

--- a/include/boost/hana/fwd/optional.hpp
+++ b/include/boost/hana/fwd/optional.hpp
@@ -38,6 +38,11 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! by the compiler. This makes `hana::optional` well suited for static
     //! metaprogramming tasks, but very poor for anything dynamic.
     //!
+    //! @note
+    //! When you use a container, remember not to make assumptions about its
+    //! representation, unless the documentation gives you those guarantees.
+    //! More details [in the tutorial](@ref tutorial-containers-types).
+    //!
     //!
     //! Interoperation with `type`s
     //! ---------------------------

--- a/include/boost/hana/fwd/pair.hpp
+++ b/include/boost/hana/fwd/pair.hpp
@@ -24,6 +24,11 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! Instead, one must use the `hana::first` and `hana::second` free
     //! functions to access the elements of a pair.
     //!
+    //! @note
+    //! When you use a container, remember not to make assumptions about its
+    //! representation, unless the documentation gives you those guarantees.
+    //! More details [in the tutorial](@ref tutorial-containers-types).
+    //!
     //!
     //! Modeled concepts
     //! ----------------

--- a/include/boost/hana/fwd/range.hpp
+++ b/include/boost/hana/fwd/range.hpp
@@ -35,7 +35,8 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! The representation of `hana::range` is implementation defined. In
     //! particular, one should not take for granted the number and types
     //! of template parameters. The proper way to create a `hana::range`
-    //! is to use `hana::range_c` or `hana::make_range`.
+    //! is to use `hana::range_c` or `hana::make_range`. More details
+    //! [in the tutorial](@ref tutorial-containers-types).
     //!
     //!
     //! Modeled concepts

--- a/include/boost/hana/fwd/set.hpp
+++ b/include/boost/hana/fwd/set.hpp
@@ -30,7 +30,8 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! In particular, one should not take for granted the order of the
     //! template parameters and the presence of any additional constructors
     //! or assignment operators than what is documented. The canonical way of
-    //! creating a `hana::set` is through `hana::make_set`.
+    //! creating a `hana::set` is through `hana::make_set`. More details
+    //! [in the tutorial](@ref tutorial-containers-types).
     //!
     //!
     //! Modeled concepts

--- a/include/boost/hana/fwd/string.hpp
+++ b/include/boost/hana/fwd/string.hpp
@@ -40,7 +40,8 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! In particular, one should not take for granted that the template
     //! parameters are `char`s. The proper way to access the contents of
     //! a `hana::string` as character constants is to use `hana::unpack`,
-    //! `.c_str()` or `hana::to<char const*>`, as documented below.
+    //! `.c_str()` or `hana::to<char const*>`, as documented below. More
+    //! details [in the tutorial](@ref tutorial-containers-types).
     //!
     //!
     //! Modeled concepts

--- a/include/boost/hana/fwd/tuple.hpp
+++ b/include/boost/hana/fwd/tuple.hpp
@@ -32,6 +32,11 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! sequence with a key-based access, then you should consider
     //! `hana::map` or `hana::set` instead.
     //!
+    //! @note
+    //! When you use a container, remember not to make assumptions about its
+    //! representation, unless the documentation gives you those guarantees.
+    //! More details [in the tutorial](@ref tutorial-containers-types).
+    //!
     //!
     //! Modeled concepts
     //! ----------------

--- a/include/boost/hana/map.hpp
+++ b/include/boost/hana/map.hpp
@@ -124,7 +124,7 @@ BOOST_HANA_NAMESPACE_BEGIN
         };
 
         template <typename HashTable, typename Storage>
-        struct map_impl
+        struct map_impl final
             : detail::searchable_operators<map_impl<HashTable, Storage>>
             , detail::operators::adl<map_impl<HashTable, Storage>>
         {

--- a/include/boost/hana/set.hpp
+++ b/include/boost/hana/set.hpp
@@ -56,7 +56,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     //////////////////////////////////////////////////////////////////////////
     //! @cond
     template <typename ...Xs>
-    struct set
+    struct set final
         : detail::operators::adl<set<Xs...>>
         , detail::searchable_operators<set<Xs...>>
     {

--- a/include/boost/hana/tuple.hpp
+++ b/include/boost/hana/tuple.hpp
@@ -75,7 +75,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     // tuple
     //////////////////////////////////////////////////////////////////////////
     template <>
-    struct tuple<>
+    struct tuple<> final
         : detail::operators::adl<tuple<>>
         , detail::iterable_operators<tuple<>>
     {
@@ -84,7 +84,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     };
 
     template <typename ...Xn>
-    struct tuple
+    struct tuple final
         : detail::operators::adl<tuple<Xn...>>
         , detail::iterable_operators<tuple<Xn...>>
     {

--- a/test/pair/empty_storage.cpp
+++ b/test/pair/empty_storage.cpp
@@ -8,16 +8,27 @@
 namespace hana = boost::hana;
 
 
+struct empty1 { };
+struct empty2 { };
+struct empty3 { };
+struct empty4 { };
+
 // Make sure the storage of a pair is compressed
-struct empty { };
-static_assert(sizeof(hana::pair<empty, int>) == sizeof(int), "");
-static_assert(sizeof(hana::pair<int, empty>) == sizeof(int), "");
+static_assert(sizeof(hana::pair<empty1, int>) == sizeof(int), "");
+static_assert(sizeof(hana::pair<int, empty1>) == sizeof(int), "");
 
 // Also make sure that a pair with only empty members is empty too. This is
 // important to ensure, for example, that a tuple of pairs of empty objects
 // will get the EBO.
-struct empty1 { };
-struct empty2 { };
 static_assert(std::is_empty<hana::pair<empty1, empty2>>{}, "");
+
+// Make sure that a pair of empty pairs is still empty.
+static_assert(std::is_empty<
+  hana::pair<hana::pair<empty1, empty2>, empty3>
+>{}, "");
+
+static_assert(std::is_empty<
+  hana::pair<hana::pair<empty1, empty2>, hana::pair<empty3, empty4>>
+>{}, "");
 
 int main() { }

--- a/test/tuple/empty_member.cpp
+++ b/test/tuple/empty_member.cpp
@@ -12,22 +12,22 @@ struct B { };
 int main() {
     {
         using T = hana::tuple<int, A>;
-        static_assert((sizeof(T) == sizeof(int)), "");
+        static_assert(sizeof(T) == sizeof(int), "");
     }
     {
         using T = hana::tuple<A, int>;
-        static_assert((sizeof(T) == sizeof(int)), "");
+        static_assert(sizeof(T) == sizeof(int), "");
     }
     {
         using T = hana::tuple<A, int, B>;
-        static_assert((sizeof(T) == sizeof(int)), "");
+        static_assert(sizeof(T) == sizeof(int), "");
     }
     {
         using T = hana::tuple<A, B, int>;
-        static_assert((sizeof(T) == sizeof(int)), "");
+        static_assert(sizeof(T) == sizeof(int), "");
     }
     {
         using T = hana::tuple<int, A, B>;
-        static_assert((sizeof(T) == sizeof(int)), "");
+        static_assert(sizeof(T) == sizeof(int), "");
     }
 }


### PR DESCRIPTION
Also, add tests to make sure that an empty pair can be EBO'd. This one is very important because a typical use case is to create a tuple of pairs of empty types (e.g. in `hana::map`), and we expect this to be empty.

Fixes #388 