### PR TITLE
[lift] Defer concept check until invocation

### DIFF
--- a/include/boost/hana/fwd/lift.hpp
+++ b/include/boost/hana/fwd/lift.hpp
@@ -49,7 +49,10 @@ BOOST_HANA_NAMESPACE_BEGIN
     struct lift_impl : lift_impl<A, when<true>> { };
 
     template <typename A>
-    struct lift_t;
+    struct lift_t {
+        template <typename X>
+        constexpr auto operator()(X&& x) const;
+    };
 
     template <typename A>
     constexpr lift_t<A> lift{};

--- a/include/boost/hana/lift.hpp
+++ b/include/boost/hana/lift.hpp
@@ -20,22 +20,22 @@ Distributed under the Boost Software License, Version 1.0.
 
 
 BOOST_HANA_NAMESPACE_BEGIN
+    //! @cond
     template <typename A>
-    struct lift_t {
-    #ifndef BOOST_HANA_CONFIG_DISABLE_CONCEPT_CHECKS
-        static_assert(hana::Applicative<A>::value,
-        "hana::lift<A> requires 'A' to be an Applicative");
-    #endif
+    template <typename X>
+    constexpr auto lift_t<A>::operator()(X&& x) const {
+        #ifndef BOOST_HANA_CONFIG_DISABLE_CONCEPT_CHECKS
+            static_assert(hana::Applicative<A>::value,
+            "hana::lift<A> requires 'A' to be an Applicative");
+        #endif
 
-        template <typename X>
-        constexpr auto operator()(X&& x) const {
-            using Lift = BOOST_HANA_DISPATCH_IF(lift_impl<A>,
-                hana::Applicative<A>::value
-            );
+        using Lift = BOOST_HANA_DISPATCH_IF(lift_impl<A>,
+            hana::Applicative<A>::value
+        );
 
-            return Lift::apply(static_cast<X&&>(x));
-        }
-    };
+        return Lift::apply(static_cast<X&&>(x));
+    }
+    //! @endcond
 
     template <typename A, bool condition>
     struct lift_impl<A, when<condition>> : default_ {


### PR DESCRIPTION
Here is my use case to justify this:

```cpp
#include <boost/hana/fwd/lift.hpp>

namespace full_duplex {
    struct promise_tag { };

    struct promise_fn {
        template <typename AsyncFn>
        constexpr auto operator()(AsyncFn&&) const;
    };

    constexpr promise_fn promise{};

    constexpr boost::hana::lift_t<promise_tag> promise_lift;
    // ^ requires promise_tag to be an Applicative before there is a chance to implement
}
```
BTW
I'm making a clean break and implementing my promise stuff as a proper `hana::Monad`.
Shameless plug: [Generalized Full Duplex Messaging](http://sched.co/EC73)