### PR TITLE
[tuple] remove superfluous conversion in example

### DIFF
--- a/example/tuple/tuple_c.cpp
+++ b/example/tuple/tuple_c.cpp
@@ -13,7 +13,7 @@ namespace hana = boost::hana;
 
 int main() {
     BOOST_HANA_CONSTANT_CHECK(
-        hana::to_tuple(hana::tuple_c<int, 0, 1, 2>)
+        hana::tuple_c<int, 0, 1, 2>
             ==
         hana::make_tuple(hana::int_c<0>, hana::int_c<1>, hana::int_c<2>)
     );


### PR DESCRIPTION
The documentation states that the result of `tuple_c` is functionally equivalent to the call to `make_tuple` so the example should not require a conversion. Correct me if I am wrong.

I've seen confusion about this before, and here is the question that prompted this:
https://stackoverflow.com/questions/50101953/why-is-the-type-of-boosthanatuple-c-implementation-defined

Thanks :smile: 