### PR TITLE
[experimental] Printable support for Visual C++

### DIFF
--- a/include/boost/hana/experimental/printable.hpp
+++ b/include/boost/hana/experimental/printable.hpp
@@ -99,7 +99,7 @@ BOOST_HANA_NAMESPACE_BEGIN namespace experimental {
 
     namespace print_detail {
         std::string strip_type_junk(std::string const& str) {
-            return std::regex_replace(str, std::regex("^([a-z_]+::)*([a-z_]*)_t<"), "$2<");
+            return std::regex_replace(str, std::regex("(?:struct )?([a-z_]+::)*([a-z_]*)_t<((?:struct )?[a-z:<>_]*)>"), "$2<$3>");
         }
     }
 

--- a/test/experimental/printable/metafunction.cpp
+++ b/test/experimental/printable/metafunction.cpp
@@ -7,6 +7,7 @@
 #include <boost/hana/integral_constant.hpp>
 #include <boost/hana/type.hpp>
 
+#include <regex>
 #include <sstream>
 namespace hana = boost::hana;
 
@@ -22,20 +23,23 @@ int main() {
         ss << hana::experimental::print(
             hana::template_<foo::my_template>
         );
-        BOOST_HANA_RUNTIME_CHECK(ss.str() == "template<foo::my_template>");
+        BOOST_HANA_RUNTIME_CHECK(std::regex_match(ss.str(),
+            std::regex("template<(?:struct )?foo::my_template>")));
     }
     {
         std::ostringstream ss;
         ss << hana::experimental::print(
             hana::metafunction<foo::my_mf>
         );
-        BOOST_HANA_RUNTIME_CHECK(ss.str() == "metafunction<foo::my_mf>");
+        BOOST_HANA_RUNTIME_CHECK(std::regex_match(ss.str(),
+            std::regex("metafunction<(?:struct )?foo::my_mf>")));
     }
     {
         std::ostringstream ss;
         ss << hana::experimental::print(
             hana::metafunction_class<foo::my_mf_class>
         );
-        BOOST_HANA_RUNTIME_CHECK(ss.str() == "metafunction_class<foo::my_mf_class>");
+        BOOST_HANA_RUNTIME_CHECK(std::regex_match(ss.str(),
+            std::regex("metafunction_class<(?:struct )?foo::my_mf_class>")));
     }
 }


### PR DESCRIPTION
  - Conditionally strips out preceding `struct` keyword since
    Microsoft's compiler includes that in the outputs of type_info::name

NOTE: I was not able to test this on Visual C++ as it is closed source and the version is likely not released.