### PR TITLE
Making overload_t's copy constructor have priority

### DIFF
--- a/include/boost/hana/functional/overload.hpp
+++ b/include/boost/hana/functional/overload.hpp
@@ -12,6 +12,7 @@ Distributed under the Boost Software License, Version 1.0.
 
 #include <boost/hana/config.hpp>
 #include <boost/hana/detail/decay.hpp>
+#include <type_traits>
 
 
 BOOST_HANA_NAMESPACE_BEGIN
@@ -47,7 +48,10 @@ BOOST_HANA_NAMESPACE_BEGIN
         using overload_t<F>::type::operator();
         using overload_t<G...>::type::operator();
 
-        template <typename F_, typename ...G_>
+        template <typename F_, typename ...G_, 
+                  typename = std::enable_if_t<
+                     !std::is_same<overload_t,std::decay_t<F_>>::value
+                 >>
         constexpr explicit overload_t(F_&& f, G_&& ...g)
             : overload_t<F>::type(static_cast<F_&&>(f))
             , overload_t<G...>::type(static_cast<G_&&>(g)...)

--- a/test/issues/github_412.cpp
+++ b/test/issues/github_412.cpp
@@ -1,0 +1,17 @@
+#include "boost/hana.hpp"
+
+constexpr int f() { return 12; }
+constexpr int g(int) { return 42; }
+
+
+
+// This test makes sure that overload can
+// be copy constructed
+int main() {
+    auto a = boost::hana::overload(f,g);
+    auto b(a);
+
+
+    BOOST_HANA_RUNTIME_CHECK(b() == 12);
+    BOOST_HANA_RUNTIME_CHECK(b(1) == 42);
+}


### PR DESCRIPTION
So currently the copy constructor for the overload_t does not take
precendent over the other templated constructor.  This means a simple
function like the following fails:

	void foo()
	{
		auto a = hana::overload(f1,f2);
		auto b(a); //Error
	}

To fix this I added a enable_if to turn off the constructor when not
applicable.........

Note: This (allegedly) fixes issue 412