### PR TITLE
Switch AppVeyor to use MSVC

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,6 +43,6 @@ before_build:
 build_script:
   - mkdir build
   - cd build
-  - cmake .. -GNinja -DCMAKE_CXX_COMPILER=clang-cl -DBOOST_ROOT=C:\Libraries\boost_1_67_0
-  #- cmake .. -GNinja -DBOOST_ROOT=C:\Libraries\boost_1_67_0
+  #- cmake .. -GNinja -DCMAKE_CXX_COMPILER=clang-cl -DBOOST_ROOT=C:\Libraries\boost_1_67_0
+  - cmake .. -GNinja -DBOOST_ROOT=C:\Libraries\boost_1_67_0
   - cmake --build . --target check


### PR DESCRIPTION
AppVeyor updated its VS2017 image to 15.8.1 on 08/29. So switch to MSVC.