### PR TITLE
Doc/fix cppreference concept links

### DIFF
--- a/doc/tutorial.hpp
+++ b/doc/tutorial.hpp
@@ -4168,7 +4168,7 @@ modified as little as possible to work with this reimplementation.
 [Chandler.MeetingC++]: https://youtu.be/qkzaZumt_uk?t=4478
 [CMake]: http://www.cmake.org
 [constexpr_throw]: http://stackoverflow.com/a/8626450/627587
-[CopyConstructible]: http://en.cppreference.com/w/cpp/concept/CopyConstructible
+[CopyConstructible]: http://en.cppreference.com/w/cpp/named_req/CopyConstructible
 [CppCon]: http://cppcon.org
 [GOTW]: http://www.gotw.ca/gotw/index.htm
 [GSoC]: http://www.google-melange.com/gsoc/homepage/google/gsoc2014
@@ -4191,7 +4191,7 @@ modified as little as possible to work with this reimplementation.
 [N4461]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4461.html
 [N4487]: https://isocpp.org/files/papers/N4487.pdf
 [pkg-config]: http://www.freedesktop.org/wiki/Software/pkg-config/
-[POD]: http://en.cppreference.com/w/cpp/concept/PODType
+[POD]: http://en.cppreference.com/w/cpp/named_req/PODType
 [SFINAE]: http://en.cppreference.com/w/cpp/language/sfinae
 [slides.inst_must_go1]: https://github.com/boostcon/2010_presentations/raw/master/mon/instantiations_must_go.pdf
 [slides.inst_must_go2]: https://github.com/boostcon/2010_presentations/raw/master/mon/instantiations_must_go_2.pdf

--- a/include/boost/hana/functional/apply.hpp
+++ b/include/boost/hana/functional/apply.hpp
@@ -35,7 +35,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! @include example/functional/apply.cpp
     //!
     //! [1]: http://en.cppreference.com/w/cpp/utility/functional/invoke
-    //! [2]: http://en.cppreference.com/w/cpp/concept/Callable
+    //! [2]: http://en.cppreference.com/w/cpp/named_req/Callable
 #ifdef BOOST_HANA_DOXYGEN_INVOKED
     constexpr auto apply = [](auto&& f, auto&& ...x) -> decltype(auto) {
         return forwarded(f)(forwarded(x)...);

--- a/include/boost/hana/fwd/concept/comparable.hpp
+++ b/include/boost/hana/fwd/concept/comparable.hpp
@@ -151,7 +151,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     //!
     //! [1]: http://en.wikipedia.org/wiki/Equivalence_relation#Definition
     //! [2]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3351.pdf
-    //! [3]: http://en.cppreference.com/w/cpp/concept/EqualityComparable
+    //! [3]: http://en.cppreference.com/w/cpp/named_req/EqualityComparable
     //! [4]: http://en.wikipedia.org/wiki/Injective_function
     template <typename T>
     struct Comparable;

--- a/include/boost/hana/fwd/concept/constant.hpp
+++ b/include/boost/hana/fwd/concept/constant.hpp
@@ -202,7 +202,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! reasons as explained above, this common type is still provided.
     //!
     //!
-    //! [1]: http://en.cppreference.com/w/cpp/concept/LiteralType
+    //! [1]: http://en.cppreference.com/w/cpp/named_req/LiteralType
     template <typename C>
     struct Constant;
 BOOST_HANA_NAMESPACE_END

--- a/include/boost/hana/fwd/concept/metafunction.hpp
+++ b/include/boost/hana/fwd/concept/metafunction.hpp
@@ -90,7 +90,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! deep comparison. Hence, we adopt a conservative stance and avoid
     //! providing comparison for `Metafunction`s.
     //!
-    //! [1]: http://en.cppreference.com/w/cpp/concept/FunctionObject
+    //! [1]: http://en.cppreference.com/w/cpp/named_req/FunctionObject
     //! [2]: http://www.boost.org/doc/libs/release/libs/mpl/doc/refmanual/metafunction-class.html
     template <typename F>
     struct Metafunction;

--- a/include/boost/hana/fwd/concept/orderable.hpp
+++ b/include/boost/hana/fwd/concept/orderable.hpp
@@ -177,7 +177,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     //!
     //!
     //! [1]: http://en.wikipedia.org/wiki/Total_order
-    //! [2]: http://en.cppreference.com/w/cpp/concept/LessThanComparable
+    //! [2]: http://en.cppreference.com/w/cpp/named_req/LessThanComparable
     //! [3]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3351.pdf
     //! [4]: http://en.wikipedia.org/wiki/Strict_weak_ordering
     template <typename Ord>


### PR DESCRIPTION
Hi,
apprently the pages under https://en.cppreference.com/w/cpp/concept/* have all been moved to https://en.cppreference.com/w/cpp/named_req/* without automatic redirection and the original link produces a 404 status code. This PR fixes all of those links (if I didn't miss any).