### PR TITLE
Add support for member function to member_ptr

### DIFF
--- a/include/boost/hana/detail/struct_macros.hpp
+++ b/include/boost/hana/detail/struct_macros.hpp
@@ -36,17 +36,13 @@ Distributed under the Boost Software License, Version 1.0.
 BOOST_HANA_NAMESPACE_BEGIN namespace struct_detail {
     template <typename Memptr, Memptr ptr>
     struct member_ptr {
-        template <typename Memptr2, typename T, std::enable_if_t<std::is_member_object_pointer_v<Memptr2>, int> = 0>
-        constexpr decltype(auto) dispatch(T && t) const
+        template <typename T, typename Memptr2 = Memptr, std::enable_if_t<std::is_member_object_pointer_v<Memptr2>, int> = 0>
+        constexpr decltype(auto) operator()(T && t) const
         { return static_cast<T&&>(t).*ptr; }
 
-        template <typename Memptr2, typename T, std::enable_if_t<std::is_member_function_pointer_v<Memptr2>, int> = 0>
-        constexpr decltype(auto) dispatch(T && t) const
-        { return [&](auto ... args) { return static_cast<T&&>(t).*ptr(args); }; }
-
-        template <typename T>
+        template <typename T, typename Memptr2 = Memptr, std::enable_if_t<std::is_member_function_pointer_v<Memptr2>, int> = 0>
         constexpr decltype(auto) operator()(T && t) const
-        { return dispatch<Memptr>(t); }
+        { return [&](auto ... args) { return static_cast<T&&>(t).*ptr(args...); }; }
     };
 
     constexpr std::size_t strlen(char const* s) {

--- a/include/boost/hana/detail/struct_macros.hpp
+++ b/include/boost/hana/detail/struct_macros.hpp
@@ -29,15 +29,20 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/tuple.hpp>
 
 #include <cstddef>
+#include <type_traits>
 #include <utility>
 
 
 BOOST_HANA_NAMESPACE_BEGIN namespace struct_detail {
     template <typename Memptr, Memptr ptr>
     struct member_ptr {
-        template <typename T>
+        template <typename T, typename = std::enable_if_t<!std::is_member_function_pointer_v<Memptr>>>
         constexpr decltype(auto) operator()(T&& t) const
         { return static_cast<T&&>(t).*ptr; }
+
+        template <typename T, typename ... Args, typename = std::enable_if_t<std::is_member_function_pointer_v<Memptr>>>
+        constexpr decltype(auto) operator()(T&& t, Args&&... args) const
+        { return (static_cast<T&&>(t).*ptr)(std::forward<Args>(args)...); }
     };
 
     constexpr std::size_t strlen(char const* s) {

--- a/include/boost/hana/detail/struct_macros.hpp.erb
+++ b/include/boost/hana/detail/struct_macros.hpp.erb
@@ -60,7 +60,7 @@ BOOST_HANA_NAMESPACE_BEGIN namespace struct_detail {
 
         template <typename Memptr2, typename T, std::enable_if_t<std::is_member_function_pointer_v<Memptr2>, int> = 0>
         constexpr decltype(auto) dispatch(T && t) const
-        { return [&](auto ... args) { return static_cast<T&&>(t).*ptr(args); }; }
+        { return [&](auto ... args) { return static_cast<T&&>(t).*ptr(args...); }; }
 
         template <typename T>
         constexpr decltype(auto) operator()(T && t) const

--- a/include/boost/hana/detail/struct_macros.hpp.erb
+++ b/include/boost/hana/detail/struct_macros.hpp.erb
@@ -54,13 +54,17 @@ Distributed under the Boost Software License, Version 1.0.
 BOOST_HANA_NAMESPACE_BEGIN namespace struct_detail {
     template <typename Memptr, Memptr ptr>
     struct member_ptr {
-        template <typename T, typename = std::enable_if_t<!std::is_member_function_pointer_v<Memptr>>>
-        constexpr decltype(auto) operator()(T&& t) const
+        template <typename Memptr2, typename T, std::enable_if_t<std::is_member_object_pointer_v<Memptr2>, int> = 0>
+        constexpr decltype(auto) dispatch(T && t) const
         { return static_cast<T&&>(t).*ptr; }
 
-        template <typename T, typename ... Args, typename = std::enable_if_t<std::is_member_function_pointer_v<Memptr>>>
-        constexpr decltype(auto) operator()(T&& t, Args&&... args) const
-        { return (static_cast<T&&>(t).*ptr)(std::forward<Args>(args)...); }
+        template <typename Memptr2, typename T, std::enable_if_t<std::is_member_function_pointer_v<Memptr2>, int> = 0>
+        constexpr decltype(auto) dispatch(T && t) const
+        { return [&](auto ... args) { return static_cast<T&&>(t).*ptr(args); }; }
+
+        template <typename T>
+        constexpr decltype(auto) operator()(T && t) const
+        { return dispatch<Memptr>(t); }
     };
 
     constexpr std::size_t strlen(char const* s) {

--- a/include/boost/hana/detail/struct_macros.hpp.erb
+++ b/include/boost/hana/detail/struct_macros.hpp.erb
@@ -54,9 +54,13 @@ Distributed under the Boost Software License, Version 1.0.
 BOOST_HANA_NAMESPACE_BEGIN namespace struct_detail {
     template <typename Memptr, Memptr ptr>
     struct member_ptr {
-        template <typename T>
+        template <typename T, typename = std::enable_if_t<!std::is_member_function_pointer_v<Memptr>>>
         constexpr decltype(auto) operator()(T&& t) const
         { return static_cast<T&&>(t).*ptr; }
+
+        template <typename T, typename ... Args, typename = std::enable_if_t<std::is_member_function_pointer_v<Memptr>>>
+        constexpr decltype(auto) operator()(T&& t, Args&&... args) const
+        { return (static_cast<T&&>(t).*ptr)(std::forward<Args>(args)...); }
     };
 
     constexpr std::size_t strlen(char const* s) {

--- a/test/concept/struct/macro.adapt_struct.cpp
+++ b/test/concept/struct/macro.adapt_struct.cpp
@@ -30,6 +30,9 @@ namespace ns {
     struct MemberArray {
         int array[10];
     };
+    struct MemberFunction {
+        int memfun(int x) { return x + 1; }
+    };
 }
 
 BOOST_HANA_ADAPT_STRUCT(ns::Data0);
@@ -37,12 +40,14 @@ BOOST_HANA_ADAPT_STRUCT(ns::Data1, member1);
 BOOST_HANA_ADAPT_STRUCT(ns::Data2, member1, member2);
 BOOST_HANA_ADAPT_STRUCT(ns::Data3, member1, member2, member3);
 BOOST_HANA_ADAPT_STRUCT(ns::MemberArray, array);
+BOOST_HANA_ADAPT_STRUCT(ns::MemberFunction, memfun);
 
 static_assert(hana::Struct<ns::Data0>::value, "");
 static_assert(hana::Struct<ns::Data1>::value, "");
 static_assert(hana::Struct<ns::Data2>::value, "");
 static_assert(hana::Struct<ns::Data3>::value, "");
 static_assert(hana::Struct<ns::MemberArray>::value, "");
+static_assert(hana::Struct<ns::MemberFunction>::value, "");
 
 int main() {
     BOOST_HANA_CONSTANT_CHECK(hana::contains(ns::Data1{}, BOOST_HANA_STRING("member1")));
@@ -55,4 +60,9 @@ int main() {
     BOOST_HANA_CONSTANT_CHECK(hana::contains(ns::Data3{}, BOOST_HANA_STRING("member3")));
 
     BOOST_HANA_CONSTANT_CHECK(hana::contains(ns::MemberArray{}, BOOST_HANA_STRING("array")));
+    
+    BOOST_HANA_CONSTANT_CHECK(hana::contains(ns::MemberFunction{}, BOOST_HANA_STRING("memfun")));
+    
+    constexpr auto accessors = hana::accessors<ns::MemberFunction>();
+    BOOST_HANA_RUNTIME_CHECK(hana::second(accessors[hana::size_c<0>])(ns::MemberFunction{})(1) == 2);
 }


### PR DESCRIPTION
This PR adds an overload of `operator()` of `member_ptr` to support member function so that the following use case is now supported:

```c++
namespace ns {
    struct Person {
        std::string name;
        int age;

        void init(std::string name_arg, int age_arg) {
            age = age_arg;
            name = name_arg;
        };

        bool is_old() const { return age > 30; };
    };
}

BOOST_HANA_ADAPT_STRUCT(ns::Person,
    name,
    age,
    init,
    is_old
);


// The member names are hana::strings:
auto names = hana::transform(hana::accessors<ns::Person>(), hana::first);
BOOST_HANA_CONSTANT_ASSERT(
    names == hana::make_tuple(BOOST_HANA_STRING("name"), BOOST_HANA_STRING("age"), BOOST_HANA_STRING("init"), BOOST_HANA_STRING("is_old"))
);

int main() {
    ns::Person john{ "John", 30 };

    constexpr auto accessors = hana::accessors<ns::Person>();
    // Call john.init()
    hana::second(accessors[hana::size_c<2>])(john, "Johnny", 31);
    // Call john.is_old()
    auto old = hana::second(accessors[hana::size_c<3>])(john);
}
```

Could you give me some guidance about adding unit tests? I had a look in `test/concept/struct` but I am not sure where the new tests belongs...