### PR TITLE
Drop support for old compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,22 +22,6 @@ matrix:
     # Note that we only use the memory checker on the main configuration to
     # speed up Travis builds.
     ##########################################################################
-    # Clang 3.5
-    - env: UNIT_TESTS=true COMPILER=clang++-3.5 BOOST_VERSION=default ENABLE_MEMCHECK=true
-      addons: { apt: { packages: ["clang-3.5", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-precise-3.5"] } }
-
-    # Clang 3.6
-    - env: UNIT_TESTS=true COMPILER=clang++-3.6 BOOST_VERSION=default ENABLE_MEMCHECK=true
-      addons: { apt: { packages: ["clang-3.6", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-precise-3.6"] } }
-
-    # Clang 3.7
-    - env: UNIT_TESTS=true COMPILER=clang++-3.7 BOOST_VERSION=default ENABLE_MEMCHECK=true
-      addons: { apt: { packages: ["clang-3.7", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-precise-3.7"] } }
-
-    # Clang 3.8
-    - env: UNIT_TESTS=true COMPILER=clang++-3.8 BOOST_VERSION=default ENABLE_MEMCHECK=true
-      addons: { apt: { packages: ["clang-3.8", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-precise-3.8"] } }
-
     # Clang 3.9
     - env: UNIT_TESTS=true COMPILER=clang++-3.9 BOOST_VERSION=default ENABLE_MEMCHECK=true
       addons: { apt: { packages: ["clang-3.9", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-3.9"] } }
@@ -69,11 +53,6 @@ matrix:
     # GCC 8
     - env: UNIT_TESTS=true COMPILER=g++-8 BOOST_VERSION=default ENABLE_MEMCHECK=true
       addons: { apt: { packages: ["g++-8", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
-
-    # Xcode 8.3
-    - os: osx
-      env: UNIT_TESTS=true BOOST_VERSION=default
-      osx_image: xcode8.3
 
     # Xcode 9.1
     - os: osx
@@ -219,11 +198,7 @@ install:
   ############################################################################
   - |
     if [[ "${CXX%%+*}" == "clang" ]]; then
-      if   [[ "${CXX}" == "clang++-3.5" ]]; then LLVM_VERSION="3.5.2";
-      elif [[ "${CXX}" == "clang++-3.6" ]]; then LLVM_VERSION="3.6.2";
-      elif [[ "${CXX}" == "clang++-3.7" ]]; then LLVM_VERSION="3.7.1";
-      elif [[ "${CXX}" == "clang++-3.8" ]]; then LLVM_VERSION="3.8.1";
-      elif [[ "${CXX}" == "clang++-3.9" ]]; then LLVM_VERSION="3.9.1";
+        if [[ "${CXX}" == "clang++-3.9" ]]; then LLVM_VERSION="3.9.1";
       elif [[ "${CXX}" == "clang++-4.0" ]]; then LLVM_VERSION="4.0.1";
       elif [[ "${CXX}" == "clang++-5.0" ]]; then LLVM_VERSION="5.0.2";
       elif [[ "${CXX}" == "clang++-6.0" ]]; then LLVM_VERSION="6.0.1";

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,5 @@
 ## These are the Release notes for the next release of Hana
-- Official support for Xcode 6 and 7 has been dropped. The library should still
-  work with these compilers, however they are not being tested regularly anymore,
-  so they are not officially supported.
+- Official support for Xcode 6, 7 and 8, and LLVM Clang 3.5, 3.6, 3.7, and 3.8
+  has has been dropped. The library should still work with these compilers,
+  however they are not being tested regularly anymore, so they are not
+  officially supported.

--- a/benchmark/make/compile.erb.json
+++ b/benchmark/make/compile.erb.json
@@ -23,13 +23,10 @@
       "data": <%= time_compilation('compile.std.array.erb.cpp', hana) %>
     }
 
-    <% if not ("@CMAKE_CXX_COMPILER_ID@" == "Clang" &&
-               "@CMAKE_CXX_COMPILER_VERSION@" == "3.5.0") %>
     , {
       "name": "std::tuple",
       "data": <%= time_compilation('compile.std.tuple.erb.cpp', std) %>
     }
-    <% end %>
 
     <% if cmake_bool("@Boost_FOUND@") %>
     , {

--- a/cmake/CheckCxxCompilerSupport.cmake
+++ b/cmake/CheckCxxCompilerSupport.cmake
@@ -8,11 +8,11 @@
 # provides friendly hints to the user.
 
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-    if (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "3.5.0")
+    if (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "3.9.1")
         message(WARNING "
     ### You appear to be using Clang ${CMAKE_CXX_COMPILER_VERSION}, which is known
     ### to be unable to compile Hana. Consider switching to
-    ### Clang >= 3.5.0. If it is already installed on your
+    ### Clang >= 3.9.1. If it is already installed on your
     ### system, you can tell CMake about it with
     ###
     ###     cmake .. -DCMAKE_CXX_COMPILER=/path/to/clang
@@ -43,7 +43,7 @@ elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
     ### shipped with Xcode < 6.3. Unfortunately, only Apple's Clang
     ### >= 6.1.0 (shipped with Xcode >= 6.3) can compile Hana.
     ### You should consider updating to Xcode >= 6.3 (requires Yosemite)
-    ### or using a non-Apple Clang >= 3.5.0, which can be installed via
+    ### or using a non-Apple Clang >= 3.9.1, which can be installed via
     ### Homebrew with
     ###
     ###     brew install llvm --with-clang

--- a/doc/js/hana.js
+++ b/doc/js/hana.js
@@ -17,7 +17,7 @@ window.onload = function() {
 
   $(".benchmark-chart").each(function(index, div) {
     var dataset = div.getAttribute("data-dataset");
-    $.getJSON("benchmarks/release/clang-3.8.0/" + dataset, function(options) {
+    $.getJSON("benchmarks/release/clang-7.1.0/" + dataset, function(options) {
       Hana.initChart($(div), options);
     });
   });

--- a/doc/tutorial.hpp
+++ b/doc/tutorial.hpp
@@ -114,13 +114,13 @@ installed.
 @subsection tutorial-installation-requirements Compiler requirements
 
 The library relies on a C++14 compiler and standard library, but nothing else
-is required. Here is a table of the current C++14 compilers/toolchains with
-comments regarding support for Hana:
+is required. However, we only guarantee support for the compilers listed
+below, which are tested on an ongoing basis:
 
 Compiler/Toolchain | Status
 ------------------ | ------
-Clang >= 3.5.0     | Fully working; tested on each push to GitHub
-Xcode >= 8.3       | Fully working; tested on each push to GitHub
+Clang >= 3.9.1     | Fully working; tested on each push to GitHub
+Xcode >= 9.1       | Fully working; tested on each push to GitHub
 GCC >= 6.0.0       | Fully working; tested on each push to GitHub
 VS2017 >= Update 7 | Fully working; tested on each push to GitHub
 
@@ -132,7 +132,9 @@ following C++14 features (non-exhaustively):
 - Automatically deduced return type
 - All the C++14 type traits from the `<type_traits>` header
 
-More information for specific platforms is available on [the wiki][Hana.wiki].
+Using a compiler not listed above may work, but support for such compilers is
+not guaranteed. More information for specific platforms is available on
+[the wiki][Hana.wiki].
 
 
 

--- a/include/boost/hana/config.hpp
+++ b/include/boost/hana/config.hpp
@@ -49,20 +49,10 @@ Distributed under the Boost Software License, Version 1.0.
 #   define BOOST_HANA_CONFIG_CLANG BOOST_HANA_CONFIG_VERSION(               \
                     __clang_major__, __clang_minor__, __clang_patchlevel__)
 
-#   if BOOST_HANA_CONFIG_CLANG < BOOST_HANA_CONFIG_VERSION(3, 5, 0)
-#       warning "Versions of Clang prior to 3.5.0 are not supported by Hana."
-#   endif
-
-#   if _MSC_VER < 1900
-#       warning "Clang-cl is only supported with the -fms-compatibility-version parameter set to 19 and above."
-#   endif
-
 #elif defined(__clang__) && defined(__apple_build_version__) // Apple's Clang
 
 #   if __apple_build_version__ >= 6020049
 #       define BOOST_HANA_CONFIG_CLANG BOOST_HANA_CONFIG_VERSION(3, 6, 0)
-#   else
-#       warning "Versions of Apple's Clang prior to the one shipped with Xcode 6.3 are known not to be able to compile Hana."
 #   endif
 
 #elif defined(__clang__) // genuine Clang
@@ -70,22 +60,10 @@ Distributed under the Boost Software License, Version 1.0.
 #   define BOOST_HANA_CONFIG_CLANG BOOST_HANA_CONFIG_VERSION(               \
                 __clang_major__, __clang_minor__, __clang_patchlevel__)
 
-#   if BOOST_HANA_CONFIG_CLANG < BOOST_HANA_CONFIG_VERSION(3, 5, 0)
-#       warning "Versions of Clang prior to 3.5.0 are not supported by Hana."
-#   endif
-
 #elif defined(__GNUC__) // GCC
 
 #   define BOOST_HANA_CONFIG_GCC BOOST_HANA_CONFIG_VERSION(                 \
                             __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
-
-#   if BOOST_HANA_CONFIG_GCC < BOOST_HANA_CONFIG_VERSION(6, 0, 0)
-#       warning "Versions of GCC prior to 6.0.0 are not supported by Hana."
-#   endif
-
-#else
-
-#   warning "Your compiler is not officially supported by Hana or it was not detected properly."
 
 #endif
 

--- a/include/boost/hana/config.hpp
+++ b/include/boost/hana/config.hpp
@@ -103,48 +103,6 @@ Distributed under the Boost Software License, Version 1.0.
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
-// Detect the standard library
-//////////////////////////////////////////////////////////////////////////////
-
-// We include this header, which normally defines the proper detection macros.
-// At least, libc++ and libstdc++ do.
-#include <cstddef>
-
-#if defined(_LIBCPP_VERSION)
-
-#   define BOOST_HANA_CONFIG_LIBCPP BOOST_HANA_CONFIG_VERSION(              \
-                ((_LIBCPP_VERSION) / 1000) % 10, 0, (_LIBCPP_VERSION) % 1000)
-
-#   if BOOST_HANA_CONFIG_LIBCPP < BOOST_HANA_CONFIG_VERSION(1, 0, 101)
-#       warning "Versions of libc++ prior to the one shipped with Clang 3.5.0 are not supported by Hana."
-#   endif
-
-#elif defined(__GLIBCXX__)
-
-// We do not define a macro to keep track of libstdc++'s version, because
-// we have no scalable way of associating a value of __GLIBCXX__ to the
-// corresponding GCC release. Instead, we just check that the release date
-// of the libstdc++ in use is recent enough, which should indicate that it
-// was released with a GCC >= 5.1, which in turn indicates good enough C++14
-// support.
-#   if __GLIBCXX__ < 20150422 // --> the libstdc++ shipped with GCC 5.1.0
-#       warning "Versions of libstdc++ prior to the one shipped with GCC 5.1.0 are not supported by Hana for lack of full C++14 support."
-#   endif
-
-#   define BOOST_HANA_CONFIG_LIBSTDCXX
-
-#elif defined(_MSC_VER)
-
-#   define BOOST_HANA_CONFIG_LIBMSVCCXX
-
-#else
-
-#   warning "Your standard library is not officially supported by Hana or it was not detected properly."
-
-#endif
-
-
-//////////////////////////////////////////////////////////////////////////////
 // Caveats and other compiler-dependent options
 //////////////////////////////////////////////////////////////////////////////
 

--- a/include/boost/hana/config.hpp
+++ b/include/boost/hana/config.hpp
@@ -168,12 +168,6 @@ Distributed under the Boost Software License, Version 1.0.
 #   define BOOST_HANA_CONSTEXPR_LAMBDA /* nothing */
 #endif
 
-// There's a bug in std::tuple_cat in libc++ right now.
-// See http://llvm.org/bugs/show_bug.cgi?id=22806.
-#if defined(BOOST_HANA_CONFIG_LIBCPP)
-#   define BOOST_HANA_CONFIG_LIBCPP_HAS_BUG_22806
-#endif
-
 //////////////////////////////////////////////////////////////////////////////
 // Namespace macros
 //////////////////////////////////////////////////////////////////////////////

--- a/include/boost/hana/ext/std/tuple.hpp
+++ b/include/boost/hana/ext/std/tuple.hpp
@@ -90,11 +90,7 @@ BOOST_HANA_NAMESPACE_BEGIN
         template <typename Xs, std::size_t ...i>
         static constexpr decltype(auto)
         flatten_helper(Xs&& xs, std::index_sequence<i...>) {
-#if defined(BOOST_HANA_CONFIG_LIBCPP_HAS_BUG_22806)
-            return std::tuple_cat(std::get<i>(xs)...);
-#else
             return std::tuple_cat(std::get<i>(static_cast<Xs&&>(xs))...);
-#endif
         }
 
         template <typename Xs>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,10 +28,8 @@ if (NOT Boost_FOUND)
     list(APPEND EXCLUDED_PUBLIC_HEADERS ${PUBLIC_HEADERS_REQUIRING_BOOST})
 endif()
 
-# The experimental::type_name test is only supported on Clang >= 3.6 and
-# AppleClang >= 7.0
-if (NOT ((${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND
-          NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.6)
+# The experimental::type_name test is only supported on Clang and AppleClang >= 7.0
+if (NOT (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"
         OR (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang" AND
             NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 7)))
     list(APPEND EXCLUDED_PUBLIC_HEADERS

--- a/test/detail/create.cpp
+++ b/test/detail/create.cpp
@@ -34,10 +34,5 @@ int main() {
     hana::detail::create<single_holder>{}(1);
     hana::detail::create<single_holder>{}([]{});
     hana::detail::create<identity_t>{}(1);
-
-    // Clang < 3.7.0 fails this test
-#if !defined(BOOST_HANA_CONFIG_CLANG) || \
-    BOOST_HANA_CONFIG_CLANG >= BOOST_HANA_CONFIG_VERSION(3, 7, 0)
     hana::detail::create<identity_t>{}([]{});
-#endif
 }


### PR DESCRIPTION
This will make it easier to support new compilers (especially the part where we remove detection of old compilers, which was broken for some new compilers).