### PR TITLE
Add function to hana::string to get the storage as a reference-to-array.

### DIFF
--- a/include/boost/hana/string.hpp
+++ b/include/boost/hana/string.hpp
@@ -64,6 +64,10 @@ BOOST_HANA_NAMESPACE_BEGIN
         static constexpr char const* c_str() {
             return &detail::string_storage<s...>[0];
         }
+
+        static constexpr auto const& c_str_ref() {
+            return detail::string_storage<s...>;
+        }
     };
     //! @endcond
 


### PR DESCRIPTION
I want to use hana::string to construct the function name provided to the boost::log macro BOOST_LOG_NAMED_SCOPE, but that macro ultimately constructs an object who's constructor has this signature:

```cpp
    template< typename T, size_type LenV >
    BOOST_CONSTEXPR basic_string_literal(T(&p)[LenV]) BOOST_NOEXCEPT;
```
Adding the "c_str_ref()" function to hana::string provides a very straightforward way to resolve this need.

For example:
```cpp
BOOST_LOG_NAMED_SCOPE(BOOST_HANA_STRING("my_function_name_here").c_str_ref());
```

Of course, the example above is a very simplified example. The real use case is to to support passing the result of compile-time string manipulation logic into the macro.