### PR TITLE
Don't define traits::is_pod in C++20 and later, since std::is_pod is …

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,4 @@
 Release notes for Hana 1.7.0
 ============================
+- Disable the definition of traits::is_pod in C++20 and later, due to its
+  deprecation.

--- a/include/boost/hana/traits.hpp
+++ b/include/boost/hana/traits.hpp
@@ -67,7 +67,9 @@ BOOST_HANA_NAMESPACE_BEGIN namespace traits {
     constexpr auto is_trivial = detail::hana_trait<std::is_trivial>{};
     constexpr auto is_trivially_copyable = detail::hana_trait<std::is_trivially_copyable>{};
     constexpr auto is_standard_layout = detail::hana_trait<std::is_standard_layout>{};
+#if __cplusplus < 202002L
     constexpr auto is_pod = detail::hana_trait<std::is_pod>{};
+#endif
     constexpr auto is_literal_type = detail::hana_trait<std::is_literal_type>{};
     constexpr auto is_empty = detail::hana_trait<std::is_empty>{};
     constexpr auto is_polymorphic = detail::hana_trait<std::is_polymorphic>{};

--- a/test/type/traits.cpp
+++ b/test/type/traits.cpp
@@ -53,7 +53,9 @@ int main() {
     hana::traits::is_trivial(s);
     hana::traits::is_trivially_copyable(s);
     hana::traits::is_standard_layout(s);
+#if __cplusplus < 202002L
     hana::traits::is_pod(s);
+#endif
     hana::traits::is_literal_type(s);
     hana::traits::is_empty(s);
     hana::traits::is_polymorphic(s);


### PR DESCRIPTION
…deprecated as of C++20.

This is a reformulation of a previous PR, now deleted.