### PR TITLE
Add "cxxstd" json field. The "cxxstd" json field is being added to ea…

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -6,5 +6,6 @@
     "description": "A modern C++ metaprogramming library. It provides high level algorithms to manipulate heterogeneous sequences, allows writing type-level computations with a natural syntax, provides tools to introspect user-defined types and much more.",
     "category": [
         "Metaprogramming"
-    ]
+    ],
+    "cxxstd": "14"
 }


### PR DESCRIPTION
…ch Boost library's meta json information for libraries whose minumum C++ standard compilation level is C++11 on up. The value of this field matches one of the values for 'cxxstd' in Boost.Build. The purpose of doing this is to provide information for the Boost website documentation for each library which will specify the minimum C++ standard compilation that an end-user must employ in order to use the particular library. This will aid end-users who want to know if they can successfully use a Boost library based on their C++ compiler's  compilation level, without having to search the library's documentation to find this out.