### PR TITLE
remove std::is_literal_type that was deprecated

### DIFF
--- a/include/boost/hana/traits.hpp
+++ b/include/boost/hana/traits.hpp
@@ -70,7 +70,9 @@ BOOST_HANA_NAMESPACE_BEGIN namespace traits {
 #if __cplusplus < 202002L
     BOOST_HANA_INLINE_VARIABLE constexpr auto is_pod = detail::hana_trait<std::is_pod>{};
 #endif
+#if __cplusplus < 201703L
     BOOST_HANA_INLINE_VARIABLE constexpr auto is_literal_type = detail::hana_trait<std::is_literal_type>{};
+#endif
     BOOST_HANA_INLINE_VARIABLE constexpr auto is_empty = detail::hana_trait<std::is_empty>{};
     BOOST_HANA_INLINE_VARIABLE constexpr auto is_polymorphic = detail::hana_trait<std::is_polymorphic>{};
     BOOST_HANA_INLINE_VARIABLE constexpr auto is_abstract = detail::hana_trait<std::is_abstract>{};

--- a/test/type/traits.cpp
+++ b/test/type/traits.cpp
@@ -56,7 +56,9 @@ int main() {
 #if __cplusplus < 202002L
     hana::traits::is_pod(s);
 #endif
+#if __cplusplus < 201703L
     hana::traits::is_literal_type(s);
+#endif
     hana::traits::is_empty(s);
     hana::traits::is_polymorphic(s);
     hana::traits::is_abstract(s);


### PR DESCRIPTION
Supports #475

- A deprecation warning is thrown (tested on gcc11 with
std=c++17), so just remove the trait for > c++14.