### PR TITLE
Add modern __cplusplus behaviour to MSVC target compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,9 @@ include(CheckCXXCompilerFlag)
 add_library(hana INTERFACE)
 target_include_directories(hana INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
 target_compile_features(hana INTERFACE cxx_std_14)
+if(MSVC)
+        target_compile_options(hana INTERFACE /Zc:__cplusplus)
+endif()
 
 # Export the `hana` library into a HanaConfig.cmake file
 install(TARGETS hana


### PR DESCRIPTION
Addition to further fix #475 without end-user CMake intervention

Adds /Zc:__cplusplus to MSVC compile options (as a `hana` target `INTERFACE` parameter) to force correct C++ standard reporting in `__cplusplus` variable.