### PR TITLE
C++20: require implicit conversion for hana::is_convertible by static_cast

### DIFF
--- a/include/boost/hana/core/to.hpp
+++ b/include/boost/hana/core/to.hpp
@@ -49,8 +49,8 @@ BOOST_HANA_NAMESPACE_BEGIN
         };
 
         template <typename To, typename From>
-        struct maybe_static_cast<To, From, decltype((void)
-            static_cast<To>(std::declval<From>())
+        struct maybe_static_cast<To, From, decltype(
+            std::declval<void(&)(To)>()(std::declval<From>())
         )> {
             template <typename X>
             static constexpr To apply(X&& x)
@@ -62,6 +62,13 @@ BOOST_HANA_NAMESPACE_BEGIN
     struct to_impl<To, From, when<condition>>
         : convert_detail::maybe_static_cast<To, From>
     { };
+
+    template <typename To, typename From>
+    struct to_impl<To, From, when<std::is_void<To>::value>> {
+        template <typename X>
+        static constexpr X apply(X&&)
+        { return; }
+    };
 
     template <typename To>
     struct to_impl<To, To> : embedding<> {


### PR DESCRIPTION
In C++20, static_cast can perform aggregate construction (__cpp_aggregate_paren_init). This breaks the example by allowing construction of Employee from its single direct base Person.

Change the maybe_static_cast control expression to require implicit conversion. Since this doesn't allow conversion to cv void, add a to_impl for cv void To.