### PR TITLE
Add missing const on operator==

### DIFF
--- a/test/issues/github_460.cpp
+++ b/test/issues/github_460.cpp
@@ -12,11 +12,11 @@ namespace hana = boost::hana;
 struct SomeStruct {
     BOOST_HANA_DEFINE_STRUCT(SomeStruct, (int, x));
 
-    constexpr bool operator==(SomeStruct const& other) {
+    constexpr bool operator==(SomeStruct const& other) const {
         return hana::equal(hana::members(*this), hana::members(other));
     }
 
-    constexpr bool operator!=(SomeStruct const& other) {
+    constexpr bool operator!=(SomeStruct const& other) const {
         return hana::not_equal(hana::members(*this), hana::members(other));
     }
 };


### PR DESCRIPTION
identified by clang14 in C++20 mode:
```
test/issues/github_460.cpp:25:33: error: ISO C++20 considers use of overloaded operator '==' (with operand types 'SomeStruct' and 'SomeStruct') to be ambiguous despite there being a unique best viable function [-Werror,-Wambiguous-reversed-operator]
    static_assert(SomeStruct{5} == SomeStruct{5}, "");
                  ~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~
test/issues/github_460.cpp:15:20: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
    constexpr bool operator==(SomeStruct const& other) {
                   ^
1 error generated.
```