### PR TITLE
Cast to void on discarded LHS of comma operator

### DIFF
--- a/include/boost/hana/core/make.hpp
+++ b/include/boost/hana/core/make.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace hana {
 
         template <typename ...X>
         static constexpr auto make_helper(long, X&& ...) {
-            static_assert((sizeof...(X), false),
+            static_assert(((void) sizeof...(X), false),
             "there exists no constructor for the given data type");
         }
 

--- a/include/boost/hana/detail/fast_and.hpp
+++ b/include/boost/hana/detail/fast_and.hpp
@@ -18,7 +18,7 @@ Distributed under the Boost Software License, Version 1.0.
 namespace boost { namespace hana { namespace detail {
     template <bool ...b>
     struct fast_and
-        : std::is_same<fast_and<b...>, fast_and<(b, true)...>>
+        : std::is_same<fast_and<b...>, fast_and<((void) b, true)...>>
     { };
 } }} // end namespace boost::hana
 


### PR DESCRIPTION
to avoid warnings in clang 14:
```
In file included from test/headers/boost/hana/any.cpp:1:
In file included from include/boost/hana/any.hpp:15:
In file included from include/boost/hana/any_of.hpp:16:
In file included from include/boost/hana/at.hpp:16:
In file included from include/boost/hana/concept/iterable.hpp:20:
In file included from include/boost/hana/drop_front.hpp:20:
In file included from include/boost/hana/integral_constant.hpp:13:
In file included from include/boost/hana/bool.hpp:17:
In file included from include/boost/hana/core/to.hpp:21:
include/boost/hana/core/make.hpp:35:28: error: left operand of comma operator has no effect [-Werror,-Wunused-value]
            static_assert((sizeof...(X), false),
                           ^~~~~~~~~~~~
```