### PR TITLE
Ported experimental::type_name for GCC

### DIFF
--- a/include/boost/hana/experimental/type_name.hpp
+++ b/include/boost/hana/experimental/type_name.hpp
@@ -3,6 +3,7 @@
 Defines `boost::hana::experimental::type_name`.
 
 @copyright Louis Dionne 2013-2017
+@copyright Denis Mikhailov 2022
 Distributed under the Boost Software License, Version 1.0.
 (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
  */
@@ -33,6 +34,11 @@ namespace boost { namespace hana { namespace experimental {
             constexpr std::size_t total_size = sizeof(__PRETTY_FUNCTION__) - 1;
             constexpr std::size_t prefix_size = sizeof("boost::hana::experimental::detail::cstring boost::hana::experimental::detail::type_name_impl2() [T = ") - 1;
             constexpr std::size_t suffix_size = sizeof("]") - 1;
+        #elif defined(__GNUC__)
+            constexpr char const* pretty_function = __PRETTY_FUNCTION__;
+            constexpr std::size_t total_size = sizeof(__PRETTY_FUNCTION__) - 1;
+            constexpr std::size_t prefix_size = sizeof("constexpr boost::hana::experimental::detail::cstring boost::hana::experimental::detail::type_name_impl2() [with T = ") - 1;
+            constexpr std::size_t suffix_size = sizeof("]") - 1;
         #else
             #error "No support for this compiler."
         #endif
@@ -51,9 +57,8 @@ namespace boost { namespace hana { namespace experimental {
     //! Returns a `hana::string` representing the name of the given type, at
     //! compile-time.
     //!
-    //! This only works on Clang (and apparently MSVC, but Hana does not work
-    //! there as of writing this). Original idea taken from
-    //! https://github.com/Manu343726/ctti.
+    //! This only works on Clang and GCC, unfortunately this not works on MSVC.
+    //! Original idea taken from https://github.com/Manu343726/ctti.
     template <typename T>
     auto type_name() {
         constexpr auto name = detail::type_name_impl2<T>();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,14 +28,15 @@ if (NOT Boost_FOUND)
     list(APPEND EXCLUDED_PUBLIC_HEADERS ${PUBLIC_HEADERS_REQUIRING_BOOST})
 endif()
 
+# TODO: add experimental::type_name build on GCC, uncomment check
 # The experimental::type_name test is only supported on Clang and AppleClang >= 7.0
-if (NOT (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"
-        OR (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang" AND
-            NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 7)))
-    list(APPEND EXCLUDED_PUBLIC_HEADERS
-        "boost/hana/experimental/type_name.hpp")
-    list(APPEND EXCLUDED_UNIT_TESTS "experimental/type_name.cpp")
-endif()
+# if (NOT (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"
+#         OR (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang" AND
+#             NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 7)))
+#     list(APPEND EXCLUDED_PUBLIC_HEADERS
+#         "boost/hana/experimental/type_name.hpp")
+#     list(APPEND EXCLUDED_UNIT_TESTS "experimental/type_name.cpp")
+# endif()
 
 # On Windows, Clang-cl emulates a MSVC bug that causes EBO not to be applied
 # properly. We disable the tests that check for EBO.


### PR DESCRIPTION
CI broken, this PR tested here: https://godbolt.org/z/ab7vdn3o8