### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,19 @@ ctest -R path.to.file # Runs the program as a test
 > file to which a target is associated (like a test or an example), you can
 > then compile it by pressing ⌘B, or compile and then run it using ⇧⌘B.
 
+## Installing LuaBridge (vcpkg)
+
+Alternatively, you can build and install hana using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```sh or powershell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install hana
+```
+
+The hana port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## Project organization
 The project is organized in a couple of subdirectories.


### PR DESCRIPTION
`hana` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `hana` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `hana`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/boost-hana/portfile.cmake). We try to keep the library maintained as close as possible to the original library.😊