### PR TITLE
Add support for "0X" hex prefix.

### DIFF
--- a/include/boost/hana/bool.hpp
+++ b/include/boost/hana/bool.hpp
@@ -157,7 +157,8 @@ namespace boost { namespace hana {
 
             if (N > 2) {
                 bool starts_with_zero = arr[0] == '0';
-                bool is_hex = starts_with_zero && arr[1] == 'x';
+                bool is_hex =
+                    starts_with_zero && (arr[1] == 'x' || arr[1] == 'X');
                 bool is_binary = starts_with_zero && arr[1] == 'b';
 
                 if (is_hex) {

--- a/test/integral_constant/udl.cpp
+++ b/test/integral_constant/udl.cpp
@@ -35,6 +35,9 @@ constexpr auto deadbeef = hana::llong_c<0xDEADBEEF>;
 BOOST_HANA_CONSTANT_CHECK(deadbeef == 0xDEADBEEF_c);
 BOOST_HANA_CONSTANT_CHECK(deadbeef == 0xDeAdBeEf_c);
 BOOST_HANA_CONSTANT_CHECK(deadbeef == 0xdeadbeef_c);
+BOOST_HANA_CONSTANT_CHECK(deadbeef == 0XDEADBEEF_c);
+BOOST_HANA_CONSTANT_CHECK(deadbeef == 0XDeAdBeEf_c);
+BOOST_HANA_CONSTANT_CHECK(deadbeef == 0Xdeadbeef_c);
 
 //decimal
 BOOST_HANA_CONSTANT_CHECK(deadbeef == hana::llong_c<3735928559>); // test the test


### PR DESCRIPTION
For integral types, you can use a capital `'X'` as part of a hex-prefix, like `0Xdeadbeef`.  This adds support for that to `ic_detail::parse()`.