### PR TITLE
This removes test project ID that will conflict with modular ID.

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -6,7 +6,7 @@ import config : requires ;
 import testing ;
 import regex ;
 
-project boost/hana :
+project :
     requirements
         <include>./_include
         <include>../include


### PR DESCRIPTION
This removes the superfluous test project ID that will conflict with the modular project IDs for all libraries. When libraries are modular they will have the standard global ID of /boost/. Having colliding IDs will cause build errors.

#modular-boost https://github.com/users/grafikrobot/projects/1
