### PR TITLE
avoid copies, when comparing maps

### DIFF
--- a/include/boost/hana/map.hpp
+++ b/include/boost/hana/map.hpp
@@ -13,6 +13,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/fwd/map.hpp>
 
 #include <boost/hana/all_of.hpp>
+#include <boost/hana/at_key.hpp>
 #include <boost/hana/basic_tuple.hpp>
 #include <boost/hana/bool.hpp>
 #include <boost/hana/concept/comparable.hpp>
@@ -39,7 +40,6 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/functional/on.hpp>
 #include <boost/hana/functional/partial.hpp>
 #include <boost/hana/fwd/any_of.hpp>
-#include <boost/hana/fwd/at_key.hpp>
 #include <boost/hana/fwd/difference.hpp>
 #include <boost/hana/fwd/erase_key.hpp>
 #include <boost/hana/fwd/intersection.hpp>
@@ -53,6 +53,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/hana/optional.hpp>
 #include <boost/hana/remove_if.hpp>
 #include <boost/hana/second.hpp>
+#include <boost/hana/set.hpp>
 #include <boost/hana/unpack.hpp>
 #include <boost/hana/value.hpp>
 
@@ -369,19 +370,29 @@ namespace boost { namespace hana {
         }
 
         template <typename M1, typename M2>
+        struct compare_at_key {
+            const M1 &m1;
+            const M2 &m2;
+            
+            template <typename K>
+            constexpr auto operator()(const K& key) const {
+                return hana::equal(hana::at_key(m1, key), hana::at_key(m2, key));
+            }
+        };
+
+        template <typename M1, typename M2>
         static constexpr auto equal_helper(M1 const& m1, M2 const& m2, hana::true_) {
-            return hana::all_of(hana::keys(m1), hana::demux(equal)(
-                hana::partial(hana::find, m1),
-                hana::partial(hana::find, m2)
-            ));
+            return hana::all_of(
+                    hana::keys(m1),
+                    equal_impl::compare_at_key<M1, M2>{m1, m2});
         }
 
         template <typename M1, typename M2>
         static constexpr auto apply(M1 const& m1, M2 const& m2) {
-            return equal_impl::equal_helper(m1, m2, hana::bool_c<
-                decltype(hana::length(m1.storage))::value ==
-                decltype(hana::length(m2.storage))::value
-            >);
+            return equal_impl::equal_helper(m1, m2, 
+                    hana::to_set(hana::keys(m1)) ==
+                    hana::to_set(hana::keys(m2))
+            );
         }
     };
 

--- a/test/map/equal.cpp
+++ b/test/map/equal.cpp
@@ -10,6 +10,9 @@
 
 #include <laws/base.hpp>
 #include <support/minimal_product.hpp>
+
+#include <memory>
+
 namespace hana = boost::hana;
 
 
@@ -94,4 +97,9 @@ int main() {
             !=
         hana::make_map(p<1, 1>(), p<2, 2>())
     );
+
+    // Check if non-copyable objects can be compared
+    auto map_unique_1 = hana::make_map(hana::make_pair(hana::integral_constant<int, 0>{}, std::make_unique<int>(0)));
+    auto map_unique_2 = hana::make_map(hana::make_pair(hana::integral_constant<int, 0>{}, std::make_unique<int>(0)));
+    BOOST_HANA_RUNTIME_CHECK(map_unique_1 != map_unique_2);
 }

--- a/test/map/equal.cpp
+++ b/test/map/equal.cpp
@@ -101,5 +101,6 @@ int main() {
     // Check if non-copyable objects can be compared
     auto map_unique_1 = hana::make_map(hana::make_pair(hana::integral_constant<int, 0>{}, std::make_unique<int>(0)));
     auto map_unique_2 = hana::make_map(hana::make_pair(hana::integral_constant<int, 0>{}, std::make_unique<int>(0)));
+    BOOST_HANA_RUNTIME_CHECK(map_unique_1 == map_unique_1);
     BOOST_HANA_RUNTIME_CHECK(map_unique_1 != map_unique_2);
 }

--- a/test/map/equal.cpp
+++ b/test/map/equal.cpp
@@ -10,8 +10,7 @@
 
 #include <laws/base.hpp>
 #include <support/minimal_product.hpp>
-
-#include <memory>
+#include <support/constexpr_move_only.hpp>
 
 namespace hana = boost::hana;
 
@@ -98,9 +97,14 @@ int main() {
         hana::make_map(p<1, 1>(), p<2, 2>())
     );
 
-    // Check if non-copyable objects can be compared
-    auto map_unique_1 = hana::make_map(hana::make_pair(hana::integral_constant<int, 0>{}, std::make_unique<int>(0)));
-    auto map_unique_2 = hana::make_map(hana::make_pair(hana::integral_constant<int, 0>{}, std::make_unique<int>(0)));
-    BOOST_HANA_RUNTIME_CHECK(map_unique_1 == map_unique_1);
-    BOOST_HANA_RUNTIME_CHECK(map_unique_1 != map_unique_2);
+    auto map_unique_1 = hana::make_map(hana::make_pair(
+        hana::integral_constant<int, 0>{},
+        ConstexprMoveOnly<0>{})
+    );
+    auto map_unique_2 = hana::make_map(hana::make_pair(
+        hana::integral_constant<int, 0>{},
+        ConstexprMoveOnly<1>{})
+    );
+    BOOST_HANA_CONSTANT_ASSERT(map_unique_1 == map_unique_1);
+    BOOST_HANA_CONSTANT_ASSERT(map_unique_1 != map_unique_2);
 }


### PR DESCRIPTION
There were two points, where copies were made:

1. When binding a map for use in `partial`.

This could be avoided, by using `std::ref`, but then either `partial` would have to handle `std::ref` in special way, by unwrapping the reference at the call point or the wrapped function would have to specify the accepted argument type explicitly to force cast.

Instead, partial was replaced with a `compare_at_key` helper struct capturing the `maps` by reference.

2. When returning the value from `find` wrapped into optional.

This is avoided by using `at_key` instead of `find`.